### PR TITLE
Fix QR code bug when certain characters are in ssid or PSK

### DIFF
--- a/release/src-rt-6.x.4708/router/www/tools-qr.asp
+++ b/release/src-rt-6.x.4708/router/www/tools-qr.asp
@@ -93,11 +93,11 @@ function tabSelect(name) {
 			var hidden = (getNvramWifiParameter(name, 'closed') == '1' ) ? 'true' : 'false';
 			var pw = (enc == 'WEP') ? getNvramWifiParameter(name, 'passphrase') : getNvramWifiParameter(name, 'wpa_psk');
 
-			E('wifi-network-ssid').innerHTML = ssid;
-			E('wifi-network-password').innerHTML = pw;
+			E('wifi-network-ssid').innerHTML = ssid.replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+			E('wifi-network-password').innerHTML = pw.replaceAll('<', '&lt;').replaceAll('>', '&gt;');
 			E('password-show-control').style.display = (enc === 'nopass') ? 'none' : 'inline';
 
-			var qrCodeContent = 'WIFI:S:'+ssid+';T:'+enc+';P:'+pw+';H:'+hidden+';;';
+			var qrCodeContent = `WIFI:S:${ssid};T:${enc};P:${pw.replaceAll(';', '\\;')};H:${hidden};;`;
 			E('qrcode').replaceChild(showQRCode(qrCodeContent), qrcode.lastChild);
 		}
 	}


### PR DESCRIPTION
When < or > are in the psk it doesn't render these chars properly, also when ; in passkey QR code doesn't generate properly