### PR TITLE
Improve UPnP IGD & PCP/NAT-PMP

### DIFF
--- a/release/src-rt-6.x.4708/router/Makefile
+++ b/release/src-rt-6.x.4708/router/Makefile
@@ -1520,7 +1520,7 @@ miniupnpd/stamp-h1:
 	$(call patch_files,miniupnpd)
 	cd miniupnpd && \
 		PKG_CONFIG_LIBDIR="" \
-		./configure --leasefile --vendorcfg --portinuse --firewall=iptables --iptablespath=$(TOP)/$(IPTABLES_TARGET) $(if $(TCONFIG_IPV6),--ipv6,)
+		./configure --leasefile --vendorcfg --portinuse --igd2 --firewall=iptables --iptablespath=$(TOP)/$(IPTABLES_TARGET) $(if $(TCONFIG_IPV6),--ipv6,)
 	@touch $@
 
 miniupnpd: miniupnpd/stamp-h1

--- a/release/src-rt-6.x.4708/router/config/Config
+++ b/release/src-rt-6.x.4708/router/config/Config
@@ -162,7 +162,7 @@ config CONFIG_PPP
        default y
 
 config CONFIG_UPNP
-       bool "UPnP IGD server"
+       bool "UPnP IGD & PCP/NAT-PMP daemon"
        depends on CONFIG_NETCONF && CONFIG_NVRAM && CONFIG_SHARED && CONFIG_NAT
        default y
 

--- a/release/src-rt-6.x.4708/router/httpd/tomato.c
+++ b/release/src-rt-6.x.4708/router/httpd/tomato.c
@@ -954,7 +954,6 @@ static const nvset_t nvset_list[] = {
 	{ "upnp_secure",		V_01				},
 	{ "upnp_port",			V_RANGE(0, 65535)		},
 	{ "upnp_ssdp_interval",		V_RANGE(10, 9999)		},
-	{ "upnp_mnp",			V_01				},
 	{ "upnp_clean",			V_01				},
 	{ "upnp_clean_interval",	V_RANGE(60, 65535)		},
 	{ "upnp_clean_threshold",	V_RANGE(0, 9999)		},

--- a/release/src-rt-6.x.4708/router/rc/services.c
+++ b/release/src-rt-6.x.4708/router/rc/services.c
@@ -1823,7 +1823,7 @@ void start_upnp(void)
 	           "upnp_nat_postrouting_chain=pupnp\n"
 	           "notify_interval=%d\n"
 	           "system_uptime=yes\n"
-	           "friendly_name=FreshTomato UPnP daemon\n"
+	           "friendly_name=FreshTomato UPnP IGD &amp; PCP\n"
 	           "model_name=%s\n"
 	           "model_url=https://freshtomato.org/\n"
 	           "manufacturer_name=FreshTomato Firmware\n"

--- a/release/src-rt-6.x.4708/router/rc/services.c
+++ b/release/src-rt-6.x.4708/router/rc/services.c
@@ -1850,13 +1850,8 @@ void start_upnp(void)
 	else
 		fprintf(f, "clean_ruleset_interval=0\n");
 
-	if (nvram_get_int("upnp_mnp")) {
-		https = nvram_get_int("https_enable");
-		fprintf(f, "presentation_url=http%s://%s:%s/forward-upnp.asp\n", (https ? "s" : ""), nvram_safe_get("lan_ipaddr"), nvram_safe_get(https ? "https_lanport" : "http_lanport"));
-	}
-	else
-		/* Empty parameters are not included into XML service description */
-		fprintf(f, "presentation_url=\n");
+	https = nvram_get_int("https_enable");
+	fprintf(f, "presentation_url=http%s://%s:%s/forward-upnp.asp\n", (https ? "s" : ""), nvram_safe_get("lan_ipaddr"), nvram_safe_get(https ? "https_lanport" : "http_lanport"));
 
 	f_read_string("/proc/sys/kernel/random/uuid", uuid, sizeof(uuid));
 	fprintf(f, "uuid=%s\n", uuid);

--- a/release/src-rt-6.x.4708/router/rc/services.c
+++ b/release/src-rt-6.x.4708/router/rc/services.c
@@ -1817,6 +1817,7 @@ void start_upnp(void)
 	           "port=%d\n"
 	           "enable_upnp=%s\n"
 	           "enable_pcp_pmp=%s\n"
+	           "force_igd_desc_v1=yes\n"
 	           "secure_mode=%s\n"
 	           "pcp_allow_thirdparty=%s\n"
 	           "upnp_forward_chain=upnp\n"

--- a/release/src-rt-6.x.4708/router/rc/services.c
+++ b/release/src-rt-6.x.4708/router/rc/services.c
@@ -1818,6 +1818,7 @@ void start_upnp(void)
 	           "enable_upnp=%s\n"
 	           "enable_pcp_pmp=%s\n"
 	           "secure_mode=%s\n"
+	           "pcp_allow_thirdparty=%s\n"
 	           "upnp_forward_chain=upnp\n"
 	           "upnp_nat_chain=upnp\n"
 	           "upnp_nat_postrouting_chain=pupnp\n"
@@ -1834,6 +1835,7 @@ void start_upnp(void)
 	           (enable & 1) ? "yes" : "no",			/* upnp enable */
 	           (enable & 2) ? "yes" : "no",			/* natpmp enable */
 	           nvram_get_int("upnp_secure") ? "yes" : "no",	/* secure_mode (only forward to self) */
+	           nvram_get_int("upnp_secure") ? "no" : "yes",
 	           nvram_get_int("upnp_ssdp_interval"),
 	           nvram_safe_get("t_model_name"));
 

--- a/release/src-rt-6.x.4708/router/rc/services.c
+++ b/release/src-rt-6.x.4708/router/rc/services.c
@@ -1837,19 +1837,6 @@ void start_upnp(void)
 	           nvram_get_int("upnp_ssdp_interval"),
 	           nvram_safe_get("t_model_name"));
 
-	if (nvram_get_int("upnp_clean")) {
-		interval = nvram_get_int("upnp_clean_interval");
-		if (interval < 60)
-			interval = 60;
-
-		fprintf(f, "clean_ruleset_interval=%d\n"
-		           "clean_ruleset_threshold=%d\n",
-		           interval,
-		           nvram_get_int("upnp_clean_threshold"));
-	}
-	else
-		fprintf(f, "clean_ruleset_interval=0\n");
-
 	https = nvram_get_int("https_enable");
 	fprintf(f, "presentation_url=http%s://%s:%s/forward-upnp.asp\n", (https ? "s" : ""), nvram_safe_get("lan_ipaddr"), nvram_safe_get(https ? "https_lanport" : "http_lanport"));
 

--- a/release/src-rt-6.x.4708/router/shared/defaults.c
+++ b/release/src-rt-6.x.4708/router/shared/defaults.c
@@ -85,7 +85,6 @@ struct nvram_tuple upnp_defaults[] = {
 	{ "upnp_secure",		"1"				, 0 },
 	{ "upnp_port",			"0"				, 0 },
 	{ "upnp_ssdp_interval",		"900"				, 0 },	/* SSDP interval */
-	{ "upnp_mnp",			"0"				, 0 },
 	{ "upnp_custom",		""				, 0 },
 	{ "upnp_lan",			""				, 0 },
 	{ "upnp_lan1",			""				, 0 },

--- a/release/src-rt-6.x.4708/router/shared/defaults.c
+++ b/release/src-rt-6.x.4708/router/shared/defaults.c
@@ -90,9 +90,6 @@ struct nvram_tuple upnp_defaults[] = {
 	{ "upnp_lan1",			""				, 0 },
 	{ "upnp_lan2",			""				, 0 },
 	{ "upnp_lan3",			""				, 0 },
-	{ "upnp_clean",			"1"				, 0 },	/* 0:Disable 1:Enable */
-	{ "upnp_clean_interval",	"600"				, 0 },	/* Cleaning interval in seconds */
-	{ "upnp_clean_threshold",	"20"				, 0 },	/* Threshold for cleaning unused rules */
 #if 0	/* disabled for miniupnpd */
 	{ "upnp_max_age",		"180"				, 0 },	/* Max age */
 	{ "upnp_config",		"0"				, 0 },

--- a/release/src-rt-6.x.4708/router/www/forward-upnp.asp
+++ b/release/src-rt-6.x.4708/router/www/forward-upnp.asp
@@ -11,7 +11,7 @@
 <head>
 <meta http-equiv="content-type" content="text/html;charset=utf-8">
 <meta name="robots" content="noindex,nofollow">
-<title>[<% ident(); %>] Forwarding: UPnP / NAT-PMP</title>
+<title>[<% ident(); %>] Forwarding: UPnP IGD &amp; PCP/NAT-PMP</title>
 <link rel="stylesheet" type="text/css" href="tomato.css?rel=<% version(); %>">
 <% css(); %>
 <script src="isup.jsz?rel=<% version(); %>"></script>
@@ -49,11 +49,11 @@ function upnpNvramAdd() {
 		return;
 
 	E('_f_enable_upnp').disabled = 1;
-	E('_f_enable_natpmp').disabled = 1;
+	E('_f_enable_pcp_pmp').disabled = 1;
 	if ((sb = E('save-button')) != null) sb.disabled = 1;
 	if ((cb = E('cancel-button')) != null) cb.disabled = 1;
 
-	if (!confirm("Add UPNP to nvram?"))
+	if (!confirm("Add UPnP IGD & PCP/NAT-PMP autonomous port forwarding service to nvram?"))
 		return;
 
 	if (xob)
@@ -76,7 +76,7 @@ function upnpNvramAdd() {
 		setTimeout(
 			function() {
 				E('_f_enable_upnp').disabled = 0;
-				E('_f_enable_natpmp').disabled = 0;
+				E('_f_enable_pcp_pmp').disabled = 0;
 				if (sb) sb.disabled = 0;
 				if (cb) cb.disabled = 0;
 				if (msg) msg.style.display = 'none';
@@ -192,7 +192,7 @@ ug.onClick = function(cell) {
 }
 
 function verifyFields(focused, quiet) {
-	var enable = (E('_f_enable_upnp').checked || E('_f_enable_natpmp').checked);
+	var enable = (E('_f_enable_upnp').checked || E('_f_enable_pcp_pmp').checked);
 	var bc = E('_f_upnp_clean').checked;
 
 	E('_f_upnp_clean').disabled = (enable == 0);
@@ -232,9 +232,9 @@ function verifyFields(focused, quiet) {
 		E('_f_upnp_lan3').checked = 0;
 
 	if ((enable) && (!E('_f_upnp_lan').checked) && (!E('_f_upnp_lan1').checked) && (!E('_f_upnp_lan2').checked) && (!E('_f_upnp_lan3').checked)) {
-		if ((E('_f_enable_natpmp').checked) || (E('_f_enable_upnp').checked)) {
-			var m = 'NAT-PMP or UPnP should be enabled on at least one LAN bridge. You can continue, but be sure to configure access to the UPnP service in Custom Configuration, otherwise miniupnpd will not run';
-			ferror.set('_f_enable_natpmp', m, quiet);
+		if ((E('_f_enable_pcp_pmp').checked) || (E('_f_enable_upnp').checked)) {
+			var m = 'Must be enabled on at least one LAN interface if no custom configuration is used, otherwise the service will not run';
+			ferror.set('_f_enable_pcp_pmp', m, quiet);
 			ferror.set('_f_enable_upnp', m, 1);
 			ferror.set('_f_upnp_lan', m, 1);
 			ferror.set('_f_upnp_lan1', m, 1);
@@ -244,7 +244,7 @@ function verifyFields(focused, quiet) {
 		return 1;
 	}
 	else {
-		ferror.clear('_f_enable_natpmp');
+		ferror.clear('_f_enable_pcp_pmp');
 		ferror.clear('_f_enable_upnp');
 		ferror.clear('_f_upnp_lan');
 		ferror.clear('_f_upnp_lan1');
@@ -264,7 +264,7 @@ function save() {
 	fom.upnp_enable.value = 0;
 	if (fom.f_enable_upnp.checked)
 		fom.upnp_enable.value = 1;
-	if (fom.f_enable_natpmp.checked)
+	if (fom.f_enable_pcp_pmp.checked)
 		fom.upnp_enable.value |= 2;
 
 	fom.upnp_mnp.value = fom._f_upnp_mnp.checked ? 1 : 0;
@@ -326,7 +326,7 @@ function init() {
 <!-- / / / -->
 
 <div id="show_ports">
-	<div class="section-title">Forwarded Ports</div>
+	<div class="section-title">Active Port Forwards</div>
 	<div class="section">
 		<div class="tomato-grid" id="upnp-grid"></div>
 		<div style="width:100%;text-align:right"><img src="spin.gif" id="refresh-spinner" alt=""> &nbsp;<input type="button" value="Delete All" onclick="deleteAll()" id="upnp-delete-all"></div>
@@ -335,12 +335,12 @@ function init() {
 
 <!-- / / / -->
 
-<div class="section-title">UPnP / NAT-PMP Settings</div>
+<div class="section-title">UPnP IGD &amp; PCP/NAT-PMP Service Settings</div>
 <div class="section">
 	<script>
 		createFieldTable('', [
-			{ title: 'Enable UPnP', name: 'f_enable_upnp', type: 'checkbox', value: (nvram.upnp_enable & 1) },
-			{ title: 'Enable NAT-PMP', name: 'f_enable_natpmp', type: 'checkbox', value: (nvram.upnp_enable & 2) },
+			{ title: 'Enable UPnP IGD', name: 'f_enable_upnp', type: 'checkbox', suffix: ' <small>This protocol is often used by Microsoft-compatible systems<\/small>', value: (nvram.upnp_enable & 1) },
+			{ title: 'Enable PCP/NAT-PMP', name: 'f_enable_pcp_pmp', type: 'checkbox', suffix: ' <small>These protocols are often used by Apple-compatible systems<\/small>', value: (nvram.upnp_enable & 2) },
 			{ title: 'Inactive Rules Cleaning', name: 'f_upnp_clean', type: 'checkbox', value: (nvram.upnp_clean == '1') },
 				{ title: 'Cleaning Interval', indent: 2, name: 'upnp_clean_interval', type: 'text', maxlen: 5, size: 7, suffix: ' <small>seconds<\/small>', value: nvram.upnp_clean_interval },
 				{ title: 'Cleaning Threshold', indent: 2, name: 'upnp_clean_threshold', type: 'text', maxlen: 4, size: 7, suffix: ' <small>redirections<\/small>', value: nvram.upnp_clean_threshold },
@@ -352,7 +352,7 @@ function init() {
 				{ title: 'LAN3', indent: 2, name: 'f_upnp_lan3', type: 'checkbox', value: (nvram.upnp_lan3 == '1') },
 			{ title: 'Show In My Network Places',  name: 'f_upnp_mnp',  type: 'checkbox',  value: (nvram.upnp_mnp == '1')},
 			null,
-			{ title: 'Miniupnpd<\/a><br>Custom configuration', name: 'upnp_custom', type: 'textarea', value: nvram.upnp_custom }
+			{ title: 'Custom Configuration', name: 'upnp_custom', type: 'textarea', value: nvram.upnp_custom }
 		]);
 	</script>
 </div>
@@ -360,7 +360,7 @@ function init() {
 <div class="section-title">Notes</div>
 <div class="section">
 	<ul>
-		<li><b>NVRAM</b> - If UPnP has been enabled, nvram values will be added. Nvram values will be removed after reboot in case UPnP will be disabled.</li>
+		<li><b>NVRAM</b> - If UPnP IGD or PCP/NAT-PMP has been enabled, nvram values will be added. Nvram values will be removed after reboot in case service will be disabled.</li>
 	</ul>
 </div>
 

--- a/release/src-rt-6.x.4708/router/www/forward-upnp.asp
+++ b/release/src-rt-6.x.4708/router/www/forward-upnp.asp
@@ -193,7 +193,7 @@ ug.onClick = function(cell) {
 function verifyFields(focused, quiet) {
 	var enable = (E('_f_enable_upnp').checked || E('_f_enable_pcp_pmp').checked);
 
-	E('_f_upnp_secure').disabled = (enable == 0);
+	E('_f_upnp_allow_third_party').disabled = (enable == 0);
 	E('_upnp_custom').disabled = (enable == 0);
 
 	E('_f_upnp_lan').disabled = ((nvram.lan_ifname.length < 1) || (enable == 0));
@@ -248,7 +248,7 @@ function save() {
 	if (fom.f_enable_pcp_pmp.checked)
 		fom.upnp_enable.value |= 2;
 
-	fom.upnp_secure.value = fom._f_upnp_secure.checked ? 1 : 0;
+	fom.upnp_secure.value = fom._f_upnp_allow_third_party.checked ? 0 : 1;
 
 	fom.upnp_lan.value = fom._f_upnp_lan.checked ? 1 : 0;
 	fom.upnp_lan1.value = fom._f_upnp_lan1.checked ? 1 : 0;
@@ -323,7 +323,7 @@ function init() {
 				{ title: 'LAN1', indent: 2, name: 'f_upnp_lan1', type: 'checkbox', value: (nvram.upnp_lan1 == '1') },
 				{ title: 'LAN2', indent: 2, name: 'f_upnp_lan2', type: 'checkbox', value: (nvram.upnp_lan2 == '1') },
 				{ title: 'LAN3', indent: 2, name: 'f_upnp_lan3', type: 'checkbox', value: (nvram.upnp_lan3 == '1') },
-			{ title: 'Secure Mode', name: 'f_upnp_secure', type: 'checkbox', suffix: ' <small>when enabled, UPnP clients are allowed to add mappings only to their IP<\/small>', value: (nvram.upnp_secure == '1') },
+			{ title: 'Allow third-party forwarding', name: 'f_upnp_allow_third_party', type: 'checkbox', suffix: ' <small>Allow adding port forwards for non-requesting IP addresses<\/small>', value: (nvram.upnp_secure == '0') },
 			{ title: 'Custom Configuration', name: 'upnp_custom', type: 'textarea', value: nvram.upnp_custom }
 		]);
 	</script>

--- a/release/src-rt-6.x.4708/router/www/forward-upnp.asp
+++ b/release/src-rt-6.x.4708/router/www/forward-upnp.asp
@@ -318,12 +318,12 @@ function init() {
 		createFieldTable('', [
 			{ title: 'Enable UPnP IGD', name: 'f_enable_upnp', type: 'checkbox', suffix: ' <small>This protocol is often used by Microsoft-compatible systems<\/small>', value: (nvram.upnp_enable & 1) },
 			{ title: 'Enable PCP/NAT-PMP', name: 'f_enable_pcp_pmp', type: 'checkbox', suffix: ' <small>These protocols are often used by Apple-compatible systems<\/small>', value: (nvram.upnp_enable & 2) },
-			{ title: 'Secure Mode', name: 'f_upnp_secure', type: 'checkbox', suffix: ' <small>when enabled, UPnP clients are allowed to add mappings only to their IP<\/small>', value: (nvram.upnp_secure == '1') },
 			{ title: 'Enabled on' },
 				{ title: 'LAN0', indent: 2, name: 'f_upnp_lan', type: 'checkbox', value: (nvram.upnp_lan == '1') },
 				{ title: 'LAN1', indent: 2, name: 'f_upnp_lan1', type: 'checkbox', value: (nvram.upnp_lan1 == '1') },
 				{ title: 'LAN2', indent: 2, name: 'f_upnp_lan2', type: 'checkbox', value: (nvram.upnp_lan2 == '1') },
 				{ title: 'LAN3', indent: 2, name: 'f_upnp_lan3', type: 'checkbox', value: (nvram.upnp_lan3 == '1') },
+			{ title: 'Secure Mode', name: 'f_upnp_secure', type: 'checkbox', suffix: ' <small>when enabled, UPnP clients are allowed to add mappings only to their IP<\/small>', value: (nvram.upnp_secure == '1') },
 			{ title: 'Custom Configuration', name: 'upnp_custom', type: 'textarea', value: nvram.upnp_custom }
 		]);
 	</script>

--- a/release/src-rt-6.x.4708/router/www/forward-upnp.asp
+++ b/release/src-rt-6.x.4708/router/www/forward-upnp.asp
@@ -47,8 +47,8 @@ function upnpNvramAdd() {
 	if (nvram.upnp_enable > 0)
 		return;
 
-	E('_f_enable_upnp').disabled = 1;
-	E('_f_enable_pcp_pmp').disabled = 1;
+	E('_f_enable_upnp').checked = 1;
+	E('_f_enable_pcp_pmp').checked = 1;
 	if ((sb = E('save-button')) != null) sb.disabled = 1;
 	if ((cb = E('cancel-button')) != null) cb.disabled = 1;
 

--- a/release/src-rt-6.x.4708/router/www/forward-upnp.asp
+++ b/release/src-rt-6.x.4708/router/www/forward-upnp.asp
@@ -136,14 +136,14 @@ function submitDelete(proto, eport) {
 }
 
 function deleteData(data) {
-	if (!confirm('Delete '+data[3]+' '+data[0]+' -> '+data[2]+':'+data[1]+' ?'))
+	if (!confirm('Delete port forward '+data[2]+'/'+data[3]+' -> '+data[0]+':'+data[1]+'?'))
 		return;
 
-	submitDelete(data[3], data[0]);
+	submitDelete(data[3], data[2]);
 }
 
 function deleteAll() {
-	if (!confirm('Delete all entries?'))
+	if (!confirm('Delete all port forwards?'))
 		return;
 
 	submitDelete('*', '0');
@@ -153,9 +153,9 @@ var ug = new TomatoGrid();
 
 ug.setup = function() {
 	this.init('upnp-grid', 'sort delete');
-	this.headerSet(['External', 'Internal', 'Internal Address', 'Protocol', 'Description']);
+	this.headerSet(['Internal Address', 'Internal Port', 'External Port', 'Protocol', 'Description']);
 	ug.populate();
-	this.sort(2);
+	this.sort(0);
 }
 
 ug.populate = function() {
@@ -168,7 +168,7 @@ ug.populate = function() {
 			if (r == null)
 				continue;
 
-			row = this.insertData(-1, [r[2], r[4], r[3], r[1], r[5]]);
+			row = this.insertData(-1, [r[3], r[4], r[2], r[1], r[5]]);
 
 			if (!r[0]) {
 				for (j = 0; j < 5; ++j) {

--- a/release/src-rt-6.x.4708/router/www/forward-upnp.asp
+++ b/release/src-rt-6.x.4708/router/www/forward-upnp.asp
@@ -19,7 +19,7 @@
 
 <script>
 
-//	<% nvram("upnp_enable,upnp_mnp,upnp_clean,upnp_secure,upnp_clean_interval,upnp_clean_threshold,upnp_custom,upnp_lan,upnp_lan1,upnp_lan2,upnp_lan3,lan_ifname,lan1_ifname,lan2_ifname,lan3_ifname"); %>
+//	<% nvram("upnp_enable,upnp_clean,upnp_secure,upnp_clean_interval,upnp_clean_threshold,upnp_custom,upnp_lan,upnp_lan1,upnp_lan2,upnp_lan3,lan_ifname,lan1_ifname,lan2_ifname,lan3_ifname"); %>
 
 </script>
 <script src="upnp.jsx?_http_id=<% nv(http_id); %>"></script>
@@ -198,7 +198,6 @@ function verifyFields(focused, quiet) {
 	E('_f_upnp_clean').disabled = (enable == 0);
 	E('_f_upnp_secure').disabled = (enable == 0);
 	E('_upnp_custom').disabled = (enable == 0);
-	E('_f_upnp_mnp').disabled = (E('_f_enable_upnp').checked == 0);
 	E('_upnp_clean_interval').disabled = (enable == 0) || (bc == 0);
 	E('_upnp_clean_threshold').disabled = (enable == 0) || (bc == 0);
 	elem.display(PR(E('_upnp_clean_interval')), (enable != 0) && (bc != 0));
@@ -267,7 +266,6 @@ function save() {
 	if (fom.f_enable_pcp_pmp.checked)
 		fom.upnp_enable.value |= 2;
 
-	fom.upnp_mnp.value = fom._f_upnp_mnp.checked ? 1 : 0;
 	fom.upnp_clean.value = fom._f_upnp_clean.checked ? 1 : 0;
 	fom.upnp_secure.value = fom._f_upnp_secure.checked ? 1 : 0;
 
@@ -313,7 +311,6 @@ function init() {
 <input type="hidden" name="_service" value="upnp-restart">
 <input type="hidden" name="_nofootermsg" value="">
 <input type="hidden" name="upnp_enable">
-<input type="hidden" name="upnp_mnp">
 <input type="hidden" name="upnp_clean">
 <input type="hidden" name="upnp_secure">
 <input type="hidden" name="upnp_lan">
@@ -350,8 +347,6 @@ function init() {
 				{ title: 'LAN1', indent: 2, name: 'f_upnp_lan1', type: 'checkbox', value: (nvram.upnp_lan1 == '1') },
 				{ title: 'LAN2', indent: 2, name: 'f_upnp_lan2', type: 'checkbox', value: (nvram.upnp_lan2 == '1') },
 				{ title: 'LAN3', indent: 2, name: 'f_upnp_lan3', type: 'checkbox', value: (nvram.upnp_lan3 == '1') },
-			{ title: 'Show In My Network Places',  name: 'f_upnp_mnp',  type: 'checkbox',  value: (nvram.upnp_mnp == '1')},
-			null,
 			{ title: 'Custom Configuration', name: 'upnp_custom', type: 'textarea', value: nvram.upnp_custom }
 		]);
 	</script>

--- a/release/src-rt-6.x.4708/router/www/forward-upnp.asp
+++ b/release/src-rt-6.x.4708/router/www/forward-upnp.asp
@@ -19,7 +19,7 @@
 
 <script>
 
-//	<% nvram("upnp_enable,upnp_clean,upnp_secure,upnp_clean_interval,upnp_clean_threshold,upnp_custom,upnp_lan,upnp_lan1,upnp_lan2,upnp_lan3,lan_ifname,lan1_ifname,lan2_ifname,lan3_ifname"); %>
+//	<% nvram("upnp_enable,upnp_secure,upnp_custom,upnp_lan,upnp_lan1,upnp_lan2,upnp_lan3,lan_ifname,lan1_ifname,lan2_ifname,lan3_ifname"); %>
 
 </script>
 <script src="upnp.jsx?_http_id=<% nv(http_id); %>"></script>
@@ -40,8 +40,7 @@ function upnpNvramAdd() {
 	var sb, cb, msg;
 
 	/* short check for upnp nvram var. If OK - nothing to do! */
-	if ((nvram.upnp_secure.length > 0) &&
-	    (nvram.upnp_clean.length > 0))
+	if (nvram.upnp_secure.length > 0)
 		return;
 
 	/* check already enabled? - nothing to do! */
@@ -193,26 +192,9 @@ ug.onClick = function(cell) {
 
 function verifyFields(focused, quiet) {
 	var enable = (E('_f_enable_upnp').checked || E('_f_enable_pcp_pmp').checked);
-	var bc = E('_f_upnp_clean').checked;
 
-	E('_f_upnp_clean').disabled = (enable == 0);
 	E('_f_upnp_secure').disabled = (enable == 0);
 	E('_upnp_custom').disabled = (enable == 0);
-	E('_upnp_clean_interval').disabled = (enable == 0) || (bc == 0);
-	E('_upnp_clean_threshold').disabled = (enable == 0) || (bc == 0);
-	elem.display(PR(E('_upnp_clean_interval')), (enable != 0) && (bc != 0));
-	elem.display(PR(E('_upnp_clean_threshold')), (enable != 0) && (bc != 0));
-
-	if ((enable != 0) && (bc != 0)) {
-		if (!v_range('_upnp_clean_interval', quiet, 60, 65535))
-			return 0;
-		if (!v_range('_upnp_clean_threshold', quiet, 0, 9999))
-			return 0;
-	}
-	else {
-		ferror.clear(E('_upnp_clean_interval'));
-		ferror.clear(E('_upnp_clean_threshold'));
-	}
 
 	E('_f_upnp_lan').disabled = ((nvram.lan_ifname.length < 1) || (enable == 0));
 	if (E('_f_upnp_lan').disabled)
@@ -266,7 +248,6 @@ function save() {
 	if (fom.f_enable_pcp_pmp.checked)
 		fom.upnp_enable.value |= 2;
 
-	fom.upnp_clean.value = fom._f_upnp_clean.checked ? 1 : 0;
 	fom.upnp_secure.value = fom._f_upnp_secure.checked ? 1 : 0;
 
 	fom.upnp_lan.value = fom._f_upnp_lan.checked ? 1 : 0;
@@ -311,7 +292,6 @@ function init() {
 <input type="hidden" name="_service" value="upnp-restart">
 <input type="hidden" name="_nofootermsg" value="">
 <input type="hidden" name="upnp_enable">
-<input type="hidden" name="upnp_clean">
 <input type="hidden" name="upnp_secure">
 <input type="hidden" name="upnp_lan">
 <input type="hidden" name="upnp_lan1">
@@ -338,9 +318,6 @@ function init() {
 		createFieldTable('', [
 			{ title: 'Enable UPnP IGD', name: 'f_enable_upnp', type: 'checkbox', suffix: ' <small>This protocol is often used by Microsoft-compatible systems<\/small>', value: (nvram.upnp_enable & 1) },
 			{ title: 'Enable PCP/NAT-PMP', name: 'f_enable_pcp_pmp', type: 'checkbox', suffix: ' <small>These protocols are often used by Apple-compatible systems<\/small>', value: (nvram.upnp_enable & 2) },
-			{ title: 'Inactive Rules Cleaning', name: 'f_upnp_clean', type: 'checkbox', value: (nvram.upnp_clean == '1') },
-				{ title: 'Cleaning Interval', indent: 2, name: 'upnp_clean_interval', type: 'text', maxlen: 5, size: 7, suffix: ' <small>seconds<\/small>', value: nvram.upnp_clean_interval },
-				{ title: 'Cleaning Threshold', indent: 2, name: 'upnp_clean_threshold', type: 'text', maxlen: 4, size: 7, suffix: ' <small>redirections<\/small>', value: nvram.upnp_clean_threshold },
 			{ title: 'Secure Mode', name: 'f_upnp_secure', type: 'checkbox', suffix: ' <small>when enabled, UPnP clients are allowed to add mappings only to their IP<\/small>', value: (nvram.upnp_secure == '1') },
 			{ title: 'Enabled on' },
 				{ title: 'LAN0', indent: 2, name: 'f_upnp_lan', type: 'checkbox', value: (nvram.upnp_lan == '1') },

--- a/release/src-rt-6.x.4708/router/www/tomato.css
+++ b/release/src-rt-6.x.4708/router/www/tomato.css
@@ -733,7 +733,7 @@ div[id$="peers-grid"] .co6,
 }
 
 #aft-grid .co3,
-#upnp-grid .co3,
+#upnp-grid .co1,
 #wol-grid .co2 {
 	width: 15%;
 }
@@ -1169,8 +1169,8 @@ div[id$="_ccd"] .co6 {
 	width: 81%;
 }
 
-#upnp-grid .co1,
-#upnp-grid .co2 {
+#upnp-grid .co2,
+#upnp-grid .co3 {
 	width: 12%;
 }
 

--- a/release/src-rt-6.x.4708/router/www/tomato.js
+++ b/release/src-rt-6.x.4708/router/www/tomato.js
@@ -2580,7 +2580,7 @@ function navi() {
 /* IPV6-END */
 			['DMZ',				'dmz.asp'],
 			['Triggered',			'triggered.asp'],
-			['UPnP/NAT-PMP',		'upnp.asp'] ] ],
+			['UPnP IGD & PCP',		'upnp.asp'] ] ],
 		['QoS',				'qos', 0, [
 			['Basic Settings',		'settings.asp'],
 			['Classification',		'classify.asp'],


### PR DESCRIPTION
- Follow upstream change miniupnp/miniupnp@02da705
- Change default `upnp_ssdp_interval` to 900s to follow specification and upstream miniupnp/miniupnp@9339f0e

Commited in 31e715b

- Improve wording and UI, include `PCP` as supported and use `UPnP IGD` as described in more detail
- Remove `Show In My Network Places` option as icon is always shown in Windows
- Remove `Inactive Rules Cleaning` options as not standard/working
- Use secure mode setting for PCP
- Improve listing and rearrange table headers
- Invert/reword secure mode

Commited in 0ce92cb

- During testing I found a issue that creating port maps/forwards for IPv6 (using PCP) does not work, daemon complains that a required ip6tables chain does not exist
- Suggested to compile IGDv2 into the daemon but disable it at runtime, see comment in next PR for reasons

Fixed in bb80103

- Restart the daemon after IPv6 is available so that its support is not deactivated (log: `no HTTP IPv6 address, disabling IPv6`)

Fixed in b137790

![freshtomato](https://github.com/user-attachments/assets/4fed9c15-18b9-4e9e-a204-5f3faf2de20f)
_[Screenshot 2024.3 release](https://github.com/user-attachments/assets/57e42a93-38f2-49f1-afd1-b3418ea453c6)_

The **Port Control Protocol (PCP)** is the successor to NAT-PMP, has similar protocol concepts and packet formats, but adds support for **IPv6 port maps** and options/extensions. For more information, see:
**Port Mapping Protocols Overview and Comparison 2024: About UPnP IGD & PCP/NAT-PMP**
https://github.com/Self-Hosting-Group/wiki/wiki/Port-Mapping-Protocols-Overview