### PR TITLE
UPnP IGD & PCP: Add `Expires` to port forward listing

### DIFF
--- a/release/src-rt-6.x.4708/router/Makefile
+++ b/release/src-rt-6.x.4708/router/Makefile
@@ -1519,7 +1519,7 @@ miniupnpd/stamp-h1:
 	$(call patch_files,miniupnpd)
 	cd miniupnpd && \
 		PKG_CONFIG_LIBDIR="" \
-		./configure --leasefile --vendorcfg --portinuse --firewall=iptables --iptablespath=$(TOP)/$(IPTABLES_TARGET) $(if $(TCONFIG_IPV6),--ipv6 --igd2,)
+		./configure --igd2 --leasefile --vendorcfg --portinuse --disable-pppconn --firewall=iptables --iptablespath=$(TOP)/$(IPTABLES_TARGET) $(if $(TCONFIG_IPV6),--ipv6,)
 	@touch $@
 
 miniupnpd: miniupnpd/stamp-h1

--- a/release/src-rt-6.x.4708/router/rc/services.c
+++ b/release/src-rt-6.x.4708/router/rc/services.c
@@ -1819,9 +1819,7 @@ void start_upnp(void)
 	           "port=%d\n"
 	           "enable_upnp=%s\n"
 	           "enable_pcp_pmp=%s\n"
-#ifdef TCONFIG_IPV6
-	           "force_igd_desc_v1=yes\n" /* If igd2 is compiled in + IPv6 support (force version 1 in IGD v2 mode) */
-#endif
+	           "force_igd_desc_v1=yes\n"
 	           "secure_mode=%s\n"
 	           "pcp_allow_thirdparty=%s\n"
 	           "upnp_forward_chain=upnp\n"
@@ -1834,6 +1832,9 @@ void start_upnp(void)
 	           "model_url=https://freshtomato.org/\n"
 	           "manufacturer_name=FreshTomato Firmware\n"
 	           "manufacturer_url=https://freshtomato.org/\n"
+	           /* Empty strings so that 1 and 00000000 are not reported */
+	           "model_number=\n"
+	           "serial=\n"
 	           "\n",
 	           get_wanface("wan"),
 	           upnp_port,

--- a/release/src-rt-6.x.4708/router/www/forward-upnp.asp
+++ b/release/src-rt-6.x.4708/router/www/forward-upnp.asp
@@ -48,7 +48,7 @@ function upnpNvramAdd() {
 	if ((sb = E('save-button')) != null) sb.disabled = 1;
 	if ((cb = E('cancel-button')) != null) cb.disabled = 1;
 
-	if (!confirm("Add UPnP IGD & PCP/NAT-PMP autonomous port forwarding service to nvram?"))
+	if (!confirm("Add UPnP IGD & PCP/NAT-PMP autonomous port forwarding service to NVRAM?"))
 		return;
 
 	if (xob)
@@ -132,7 +132,7 @@ function submitDelete(proto, eport) {
 }
 
 function deleteData(data) {
-	if (!confirm('Delete port forward '+data[2]+'/'+data[3]+' -> '+data[0]+':'+data[1]+'?'))
+	if (!confirm('Delete port forward for '+data[0]+':'+data[1]+'/'+data[3]+' ('+data[5]+')?'))
 		return;
 
 	submitDelete(data[3], data[2]);
@@ -145,11 +145,17 @@ function deleteAll() {
 	submitDelete('*', '0');
 }
 
+function padnum(num, length) {
+	num = num.toString();
+	while (num.length < length) num = "0" + num;
+	return num;
+}
+
 var ug = new TomatoGrid();
 
 ug.setup = function() {
 	this.init('upnp-grid', 'sort delete');
-	this.headerSet(['Internal Address', 'Internal Port', 'External Port', 'Protocol', 'Description']);
+	this.headerSet(['Client Address', 'Client Port', 'Ext Port', 'Protocol', 'Expires', 'Description']);
 	ug.populate();
 	this.sort(0);
 }
@@ -164,13 +170,27 @@ ug.populate = function() {
 			if (r == null)
 				continue;
 
-			row = this.insertData(-1, [r[3], r[4], r[2], r[1], r[5]]);
+			var expires_sec, hour, minute, second, expires_str = '';
+			expires_sec = (new Date(r[6] * 1000) - new Date().getTime()) / 1000;
+			hour = Math.floor(expires_sec / 3600);
+			minute = Math.floor(expires_sec % 3600 / 60);
+			second = Math.floor(expires_sec % 60);
+			if (hour > 0) {
+				expires_str += hour + 'h ';
+				expires_str += padnum(minute, 2) + 'm ';
+				expires_str += padnum(second, 2) + 's';
+			} else if (minute > 0) {
+				expires_str += minute + 'm ';
+				expires_str += padnum(second, 2) + 's';
+			} else if (expires_sec > 0) expires_str += second + 's';
+
+			row = this.insertData(-1, [r[3], r[4], r[2], r[1], expires_str, r[5]]);
 
 			if (!r[0]) {
-				for (j = 0; j < 5; ++j)
+				for (j = 0; j < 6; ++j)
 					elem.addClass(row.cells[j], 'disabled');
 			}
-			for (j = 0; j < 5; ++j)
+			for (j = 0; j < 6; ++j)
 				row.cells[j].title = 'Delete';
 		}
 	}
@@ -188,7 +208,7 @@ ug.onClick = function(cell) {
 function verifyFields(focused, quiet) {
 	var enable = (E('_f_enable_upnp').checked || E('_f_enable_pcp_pmp').checked);
 
-	E('_f_upnp_secure').disabled = !enable;
+	E('_f_upnp_allow_third_party').disabled = !enable;
 	E('_upnp_custom').disabled = !enable;
 
 	for (var i = 0 ; i <= MAX_BRIDGE_ID ; i++) {
@@ -234,7 +254,7 @@ function save() {
 	if (fom.f_enable_pcp_pmp.checked)
 		fom.upnp_enable.value |= 2;
 
-	fom.upnp_secure.value = fom._f_upnp_secure.checked ? 0 : 1;
+	fom.upnp_secure.value = fom._f_upnp_allow_third_party.checked ? 0 : 1;
 
 	fom.upnp_lan.value = fom._f_upnp_lan.checked ? 1 : 0;
 	fom.upnp_lan1.value = fom._f_upnp_lan1.checked ? 1 : 0;
@@ -309,7 +329,7 @@ function init() {
 				{ title: 'LAN1', indent: 2, name: 'f_upnp_lan1', type: 'checkbox', value: (nvram.upnp_lan1 == 1) },
 				{ title: 'LAN2', indent: 2, name: 'f_upnp_lan2', type: 'checkbox', value: (nvram.upnp_lan2 == 1) },
 				{ title: 'LAN3', indent: 2, name: 'f_upnp_lan3', type: 'checkbox', value: (nvram.upnp_lan3 == 1) },
-			{ title: 'Allow third-party forwarding', name: 'f_upnp_secure', type: 'checkbox', suffix: ' <small>Allow adding port forwards for non-requesting IP addresses<\/small>', value: (nvram.upnp_secure == 0) },
+			{ title: 'Allow third-party forwarding', name: 'f_upnp_allow_third_party', type: 'checkbox', suffix: ' <small>Allow adding port forwards for non-requesting IP addresses<\/small>', value: (nvram.upnp_secure == 0) },
 			{ title: 'Custom Configuration', name: 'upnp_custom', type: 'textarea', value: nvram.upnp_custom }
 		]);
 	</script>

--- a/release/src-rt-6.x.4708/router/www/tomato.css
+++ b/release/src-rt-6.x.4708/router/www/tomato.css
@@ -733,7 +733,6 @@ div[id$="peers-grid"] .co6,
 }
 
 #aft-grid .co3,
-#upnp-grid .co1,
 #wol-grid .co2 {
 	width: 15%;
 }
@@ -1169,15 +1168,6 @@ div[id$="_ccd"] .co6 {
 	width: 81%;
 }
 
-#upnp-grid .co2,
-#upnp-grid .co3 {
-	width: 12%;
-}
-
-#upnp-grid .co5 {
-	width: 53%;
-}
-
 #tg-grid .co1,
 div[id$="_ccd"] .co1,
 div[id$="_users"] .co1 {
@@ -1287,8 +1277,7 @@ div[id$="peers-grid"] .co2,
 	text-align: center;
 }
 
-#pbr-grid .co2,
-#upnp-grid .co4 {
+#pbr-grid .co2 {
 	width: 8%;
 }
 
@@ -1321,6 +1310,28 @@ div[id$="peers-grid"] .co2,
 #adblock-grid .co1 {
 	width: 5%;
 	text-align: center;
+}
+
+#upnp-grid .co1 {
+	width: 33%;
+}
+
+#upnp-grid .co2 {
+	width: 10%;
+}
+
+#upnp-grid .co3,
+#upnp-grid .co4 {
+	width: 8%;
+}
+
+#upnp-grid .co5 {
+	width: 11%;
+	text-align: right;
+}
+
+#upnp-grid .co6 {
+	width: 30%;
 }
 
 #adblock-grid .co2 {


### PR DESCRIPTION
- Add `Expires` to port forward listing
- Improve UI and wording
- Compile daemon with IGDv2 (`--igd2`) by default for all builds, but disable it by default at runtime to workaround IGDv2 incompatible clients, but have the benefit of limit infinite port maps to a maximum of 7d and return more accurate errors
- Compile daemon with `--disable-pppconn` as legacy workaround

![freshtomato](https://github.com/user-attachments/assets/ae81d6fa-bcc6-4f90-93cb-9c4a0cfcb071)
_[Screenshot 2024.3 release](https://github.com/user-attachments/assets/57e42a93-38f2-49f1-afd1-b3418ea453c6)_

The **Port Control Protocol (PCP)** is the successor to NAT-PMP, has similar protocol concepts and packet formats, but adds support for **IPv6 port maps** and options/extensions. For more information, see:
**Port Mapping Protocols Overview and Comparison 2024: About UPnP IGD & PCP/NAT-PMP**
https://github.com/Self-Hosting-Group/wiki/wiki/Port-Mapping-Protocols-Overview

Previous improvement: #4