### PR TITLE
GUI: admin-upgrade.asp - allow full filename display

### DIFF
--- a/release/src-rt-6.x.4708/router/www/tomato.css
+++ b/release/src-rt-6.x.4708/router/www/tomato.css
@@ -1071,7 +1071,10 @@ img[id^="barnoise_"] {
 	width: 23%;
 }
 
-.upgrade-file,
+.upgrade-file {
+	width: 440px;
+}
+
 .import-file,
 #qos-cl-grid .x2c {
 	width: 41%;


### PR DESCRIPTION
This change allows displaying the full file name (as distributed by FreshTomato) before the upgrade button is pressed. 

Prior to this change, firmware file names are getting truncated on both standard and advanced themes.