### PR TITLE
tomato.css - extend maximum number of visible characters in upgreade/filename

### DIFF
--- a/release/src-rt-6.x.4708/router/www/tomato.css
+++ b/release/src-rt-6.x.4708/router/www/tomato.css
@@ -1078,7 +1078,12 @@ img[id^="barnoise_"] {
 	width: 23%;
 }
 
-.upgrade-file,
+.upgrade-file {
+    width: 90%;
+    overflow: auto;
+    white-space: nowrap;
+}
+
 .import-file,
 #qos-cl-grid .x2c {
 	width: 41%;

--- a/release/src-rt-6.x.4708/router/www/tomato.css
+++ b/release/src-rt-6.x.4708/router/www/tomato.css
@@ -1079,9 +1079,9 @@ img[id^="barnoise_"] {
 }
 
 .upgrade-file {
-    width: 90%;
-    overflow: auto;
-    white-space: nowrap;
+	width: 90%;
+	overflow: auto;
+	white-space: nowrap;
 }
 
 .import-file,


### PR DESCRIPTION
Prevents filename truncation for long filename in the upgrade "select file" field
(tested with basic and advanced themes and also on android)