### PR TITLE
GUI: admin-upgrade.asp - layout improvement

### DIFF
--- a/release/src-rt-6.x.4708/router/www/admin-upgrade.asp
+++ b/release/src-rt-6.x.4708/router/www/admin-upgrade.asp
@@ -88,18 +88,19 @@ function earlyInit() {
 	<div class="section">
 		<div class="fields" id="upgradenotice" style="display:none"><div class="about"><b>Note: Remote upgrade is disabled. You can enable it (not recommended) <a href="admin-access.asp">here</a>.</b></div></div>
 		<div>
-			<div class="afu-form">Select the file to use:</div>
-			<form name="form_upgrade" method="post" action="upgrade.cgi" enctype="multipart/form-data">
-				<div class="afu-form">
-					<input type="file" name="file" class="upgrade-file"> <input type="button" id="afu-upgrade-button" value="Upgrade" onclick="upgrade()">
-				</div>
-			</form>
 			<form name="form_reset" action="javascript:{}">
 				<div class="afu-form">
-					<input type="checkbox" id="f_reset">&nbsp; Erase NVRAM configuration and restore firmware defaults
+					<input type="checkbox" id="f_reset">&nbsp; &nbsp; Erase all data in NVRAM. Optional. This is performed between the firmware upload and the reboot.
 				</div>
 			</form>
-
+			<div class="afu-form">Select a valid <a href="https://freshtomato.org/downloads/">firmware</a> to install (.trx or .bin):</div>
+			<form name="form_upgrade" method="post" action="upgrade.cgi" enctype="multipart/form-data">
+				<div class="afu-form">
+					<input type="file" name="file" class="upgrade-file">
+					<p>
+					<input type="button" id="afu-upgrade-button" value="Upgrade" sizeonclick="upgrade()">
+				</div>
+			</form>
 			<table class="afu-info-table"><tr>
 				<td>Current Version:</td>
 				<td>&nbsp; <% version(1); %></td>


### PR DESCRIPTION
- Re-organised layout
- Allows for long filenames to be fully visible now
- moved "clear NVRAM" above the Upgrade button as the option is dependent on it

(apologies about the prev PR, there was indeed an issue with the tabulation within Visual Studio Code as the program by default replaces tabs with spaces). Go figure...