### PR TITLE
Network discovery v2.62

### DIFF
--- a/release/src-rt-6.x.4708/router/httpd/tomato.c
+++ b/release/src-rt-6.x.4708/router/httpd/tomato.c
@@ -2110,15 +2110,56 @@ static void asp_css(int argc, char **argv)
 }
 
 #if defined(TCONFIG_BCMARM) || defined(TCONFIG_MIPSR2)
-static void asp_discovery(int argc, char **argv)
-{
-	char buf[64] = "/usr/sbin/discovery.sh ";
+static void asp_discovery(int argc, char **argv) {
+	char buf[128] = "/usr/sbin/discovery.sh ";
 
-	if (strncmp(argv[0], "off", 3) == 0)
+	if (argc == 0 || (argc == 1 && strcmp(argv[0], "off") == 0))
+	return;
+
+	// Include 'arping' as a valid command
+	const char* valid_commands[] = {"arping", "traceroute", "nc", "all"};
+	int valid_command = 0;
+
+	for (int i = 0; i < sizeof(valid_commands)/sizeof(valid_commands[0]); i++) {
+		if (strcmp(argv[0], valid_commands[i]) == 0) {
+			valid_command = 1;
+			strlcat(buf, argv[0], sizeof(buf));
+		break;
+	}
+	}
+
+	if (!valid_command) {
+		fprintf(stderr, "Invalid discovery command: %s\n", argv[0]);
 		return;
-	else if (strncmp(argv[0], "traceroute", 10) == 0)
-		strlcat(buf, argv[0], sizeof(buf));
+	}
 
+	// Append target (wan/lan/both)
+	if (argc > 1) {
+	 const char *target = argv[1];
+	if (strcmp(target, "lan") == 0 || strcmp(target, "wan") == 0 || strcmp(target, "both") == 0) {
+		strlcat(buf, " ", sizeof(buf));
+		strlcat(buf, target, sizeof(buf));
+	}
+	}
+
+	// Append 'clear' flag
+	if (argc > 2 && strcmp(argv[2], "clear") == 0) {
+		strlcat(buf, " clear", sizeof(buf));
+	}
+
+	// Append probe limit (numeric)
+	if (argc > 3) {
+		int is_number = 1;
+	 	for (const char *p = argv[3]; *p; ++p) {
+			if (!isdigit(*p)) {
+			is_number = 0;
+			break;
+			}
+	}
+	if (is_number) {
+		snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), " %s", argv[3]);
+	}
+	}
 	system(buf);
 }
 #endif

--- a/release/src-rt-6.x.4708/router/others/discovery.sh
+++ b/release/src-rt-6.x.4708/router/others/discovery.sh
@@ -57,7 +57,7 @@ check_procs() {
 		arping) pidof arping ;;
 		traceroute) pidof traceroute ;;
 		nc) pidof nc ;;
-		discovery) pidof discovery.sh | grep -vw "$$" ;;
+		discovery) pidof discovery.sh | sed "s/\b$$\b//;s/  */ /g" ;;
 	esac | wc -w
 }
 
@@ -93,10 +93,10 @@ for param in "$@"; do
 done
 [ "$runlan" -eq 0 ] && [ "$runwan" -eq 0 ] && runlan=1
 
-[ "$(check_procs discovery)" -gt 0 -a "$fkill" -ne 1 ] {
-	echo "Network Discovery - Background processes already running; skipping this run." | tee /dev/tty | logger
+if [ "$(check_procs discovery)" -gt 0 -a "$fkill" -ne 1 ]; then
+	echo "Status-devices - Background discovery processes already running; skipping this run." | tee /dev/tty | logger
 	exit
-}
+fi
 
 scanthis() {
 	for iface in $this; do

--- a/release/src-rt-6.x.4708/router/others/discovery.sh
+++ b/release/src-rt-6.x.4708/router/others/discovery.sh
@@ -57,7 +57,7 @@ check_procs() {
 		arping) pidof arping ;;
 		traceroute) pidof traceroute ;;
 		nc) pidof nc ;;
-	esac | wc -l
+	esac | wc -w
 }
 
 md5_param=$(echo "$@" | md5sum | cut -d' ' -f1)

--- a/release/src-rt-6.x.4708/router/others/discovery.sh
+++ b/release/src-rt-6.x.4708/router/others/discovery.sh
@@ -1,41 +1,163 @@
 #!/bin/sh
 export PATH=/bin:/usr/bin:/sbin:/usr/sbin:/home/root
-# Network discovery script v2.0 - ARM and MIPSR2 - 05/2024 - rs232
+# Network discovery script v2.62 - ARM and MIPSR2 - 02/2025 - rs232 
 #------------------------------------------------------
-#    FreshTomato Network Discovery - usage
+#	FreshTomato Network Discovery - usage
 #
-#    default (or arping) = arping scanning
-#    traceroute = uses a traceroute discovery
+#	arping = * scanning via arping (preferred)
+#	traceroute = scanning via traceroute 
+#	nc = scanning via netcat
+#	all = all the above in round-robin
+#
+#	lan = * only LANs interfaces
+#	wan = only WANs interfaces
+#	both = scan LANs and WANs
+#
+#	clear = removes dirty records from the arp table post scan
+#
+#	<5-200> = default 60, maximum number of concurrent scans
 #------------------------------------------------------
+debug=$(nvram get discovery_debug 2>/dev/null)
+debug="${debug:-0}"
+[ "$debug" -eq 1 ] && { echo "Debugging..."; date >> /tmp/discovery.debug; echo "$@" >> /tmp/discovery.debug; }
+lim=$(echo "$@" | grep -oE '[0-9]+' | head -n 1 | awk '{if($1 < 5) print 5; else if($1 > 200) print 200; else print $1}')
+[ -z "$lim" ] && lim=60
+alias slp='usleep 250000'
+alias low='nice -n 19'
+tmp="/tmp/discovery.tmp"
+scan=0
+cl=0
+runlan=0
+runwan=0
+fkill=0
 
 iplist() {
-input_cidr="$1"
-subnet_mask=$(echo "$input_cidr" | cut -d '/' -f 2)
-num_addresses=$((2 ** (32 - subnet_mask)))
-ip_address=$(echo "$input_cidr" | cut -d '/' -f 1)
-ip_int=0
-for octet in $(echo "$ip_address" | tr '.' ' '); do
-	ip_int=$((ip_int * 256 + octet))
-done
-first_ip_int=$((ip_int & ~(num_addresses - 1)))
-last_ip_int=$((first_ip_int + num_addresses - 1))
-for i in $(seq 1 $((num_addresses - 2))); do
-	current_ip_int=$((first_ip_int + i))
-	printf "%d.%d.%d.%d\n" $((current_ip_int >> 24 & 255)) $((current_ip_int >> 16 & 255)) $((current_ip_int >> 8 & 255)) $((current_ip_int & 255))
-done
+	input_cidr="$1"
+	cidr=$(echo "$input_cidr" | cut -d '/' -f 2)
+	ip=$(echo "$input_cidr" | cut -d '/' -f 1)
+	awk -v cidr="$cidr" -v ip="$ip" '
+	BEGIN {
+		split(ip, a, ".");
+		ip_int = a[1] * 256^3 + a[2] * 256^2 + a[3] * 256 + a[4];
+		num_addrs = 2^(32 - cidr);
+		base_ip = int(ip_int / num_addrs) * num_addrs;
+		for (i = 1; i < num_addrs - 1; i++) {
+		current_ip = base_ip + i;
+		printf "%d.%d.%d.%d\n",
+		int(current_ip / 256^3) % 256,
+		int(current_ip / 256^2) % 256,
+		int(current_ip / 256) % 256,
+		current_ip % 256;
+		}
+	}'
 }
 
-[ "$(ps w | grep 'traceroute -i\ | arping -q' | grep -v grep | wc -l)" -gt 0 ] && {
-	logger "Device List Discovery already running - exiting ..."
+check_procs() {
+	case "$1" in
+		arping) pidof arping ;;
+		traceroute) pidof traceroute ;;
+		nc) pidof nc ;;
+	esac | wc -l
+}
+
+md5_param=$(echo "$@" | md5sum | cut -d' ' -f1)
+if [ -f "$tmp" ]; then
+	if ! grep -q "$md5_param" "$tmp"; then
+		# Kill previous instances with different parameters
+		for PID in $(ps | grep "{discovery.sh}.*$*" | grep -vw "$$" | awk '{print $1}'); do
+		[ "$PID" != "$$" ] && kill -9 "$PID" &>/dev/null
+		done
+		# Kill scanning tools
+		for tool in arping traceroute nc; do
+		[ "$(check_procs "$tool")" -gt 0 ] && killall -q "$tool"
+		done
+		sleep 1
+		fkill=1
+	fi
+else
+	echo 0 > "$tmp"
+	echo "$md5_param" >> "$tmp"
+fi
+
+for param in "$@"; do
+	case "$param" in
+		clear)     cl=1 ;;
+		lan)       runlan=1 ;;
+		wan)       runlan=0; runwan=1 ;;
+		both)      runlan=1; runwan=1 ;;
+		traceroute) scan=1 ;;
+		nc)        scan=2 ;;
+		all)       scan=$(head -1 "$tmp") ;;
+	esac
+done
+[ "$runlan" -eq 0 ] && [ "$runwan" -eq 0 ] && runlan=1
+
+[ "$(ps | grep -c '[t]raceroute -i\|[a]rping -I\|[n]c -w')" -gt 5 -a "$fkill" -ne 1 ] && {
+	echo "Status-devices - Background discovery processes already running; skipping this run." | tee /dev/tty | logger
 	exit
 }
 
-for bridge in $(brctl show | grep -Eo ^br[0-9]); do
-	cidr=$(ip addr list dev $bridge | grep inet | awk '{print $2}')
-	ip=$(echo $cidr | cut -d/ -f1)
-	iplist $cidr | while read -r ip_address; do
-		if [ -z $1 ] || [ $1 == "arping" ]; then usleep 1500 && arping -q -c1 -w1 -I $bridge $ip_address &>/dev/null &
-		elif [ $1 == "traceroute" ]; then traceroute -i $bridge -r -F -m1 -q1 -s $ip $ip_address &>/dev/null &
-		fi
+scanthis() {
+	for iface in $this; do
+		cidr=$(ip a l dev "$iface" | grep inet | awk '{print $2}')
+		[ "$(echo "$cidr" | cut -d/ -f2)" -lt 22 ] && {
+			echo "$iface - subnet mask shorter than /22. Too many IPs to scan - skipping..." | tee /dev/tty | logger
+			continue
+		}
+	[ "$(echo "$cidr" | cut -d/ -f2)" -lt 32 ] && {
+		ip=$(echo "$cidr" | cut -d/ -f1)
+		ipn=$(ip neigh show dev "$iface" | grep 'REACHABLE\|PERMANENT' | grep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
+		iplist "$cidr" | grep -vwE "$ip|$(echo "$ipn" | tr ' ' '\n')" | while read -r ip_addr; do
+			if [ "$scan" -eq 0 ]; then
+				while [ "$(check_procs arping)" -gt "$lim" ]; do slp; done
+				low arping -I "$iface" -q -c1 -w1 "$ip_addr" &>/dev/null &
+			elif [ "$scan" -eq 1 ]; then
+				while [ "$(check_procs traceroute)" -gt "$lim" ]; do slp; done
+				low traceroute -i "$iface" -r -F -m1 -q1 -s "$ip" "$ip_addr" &>/dev/null &
+			elif [ "$scan" -eq 2 ]; then
+				while [ "$(check_procs nc)" -gt "$lim" ]; do slp; done
+				low nc -w 1 "$ip_addr" &>/dev/null &
+			fi
 	done
-done
+	wait
+	}
+	done
+}
+
+prune() {
+	ip n | grep -w "$1" | while read -r badip; do
+		ip=$(echo "$badip" | awk '{print $1}')
+		dev=$(echo "$badip" | awk '{print $3}')
+		ip neigh change "$ip" nud none dev "$dev"
+	done
+}
+
+[ "$runlan" -eq 1 ] && {
+	this=$(brctl show | grep -Eo ^br[0-9])
+	scanthis
+}
+
+unset wans
+[ "$runwan" -eq 1 ] && {
+	[ "$(ip rule | grep -Eo 'WAN[1-4]' | sort -u | wc -l)" -gt 0 ] && {
+		for WAN in $(ip rule | grep -Eo 'WAN[1-4]' | sort -u); do
+		wans="$wans $(ip r l t "$WAN" | grep -Eo '[vlan|eth]+[0-9]{1,4}')"
+	done
+	} || {
+		wans=$(ip route | grep ^default | awk '{print $5}')
+	}
+	this="$wans"
+	scanthis
+}
+
+[ "$cl" -eq 1 ] && {
+	prune "FAILED\|INCOMPLETE"
+	usleep $((lim * 30000))
+	prune "STALE\|DELAY\|PROBE"
+}
+
+scan=$(((${scan:-0} + 1) % 3))
+{
+	echo "$scan"
+	echo "$md5_param"
+} >> "$tmp"

--- a/release/src-rt-6.x.4708/router/others/discovery.sh
+++ b/release/src-rt-6.x.4708/router/others/discovery.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 export PATH=/bin:/usr/bin:/sbin:/usr/sbin:/home/root
-# Network discovery script v2.62 - ARM and MIPSR2 - 02/2025 - rs232 
+# Network discovery script v2.63 - ARM and MIPSR2 - 02/2025 - rs232 
 #------------------------------------------------------
 #	FreshTomato Network Discovery - usage
 #
@@ -57,6 +57,7 @@ check_procs() {
 		arping) pidof arping ;;
 		traceroute) pidof traceroute ;;
 		nc) pidof nc ;;
+		discovery) pidof discovery.sh | grep -vw "$$" ;;
 	esac | wc -w
 }
 
@@ -92,8 +93,8 @@ for param in "$@"; do
 done
 [ "$runlan" -eq 0 ] && [ "$runwan" -eq 0 ] && runlan=1
 
-[ "$(ps | grep -c '[t]raceroute -i\|[a]rping -I\|[n]c -w')" -gt 5 -a "$fkill" -ne 1 ] && {
-	echo "Status-devices - Background discovery processes already running; skipping this run." | tee /dev/tty | logger
+[ "$(check_procs discovery)" -gt 0 -a "$fkill" -ne 1 ] {
+	echo "Network Discovery - Background processes already running; skipping this run." | tee /dev/tty | logger
 	exit
 }
 

--- a/release/src-rt-6.x.4708/router/www/status-devices.asp
+++ b/release/src-rt-6.x.4708/router/www/status-devices.asp
@@ -32,9 +32,13 @@ var xob = null;
 var cmd = null;
 var wol = null;
 var cmdresult = '';
-/* DISCOVERY-BEGIN */
 var cprefix = 'status_devices';
-var discovery_mode = cookie.get(cprefix+'_discovery') || 'off';
+/* DISCOVERY-BEGIN */
+var discovery_clear = parseInt(cookie.get(cprefix + '_discovery_clear')) || 0;
+var clear2 = (discovery_clear === 1) ? 'clear' : '';
+var discovery_limit = cookie.get(cprefix+'_discovery_limit') || '60';
+var discovery_target = cookie.get(cprefix+'_discovery_target') || 'lan';
+var discovery_mode = cookie.get(cprefix+'_discovery_mode') || 'off';
 var wait = gc_time;
 var time_o;
 /* DISCOVERY-END */
@@ -60,7 +64,7 @@ ref.refresh = function(text) {
 }
 
 /* DISCOVERY-BEGIN */
-var discovery = new TomatoRefresh('update.cgi', 'exec=discovery&arg0='+discovery_mode, gc_time, '', 1);
+var discovery = new TomatoRefresh('update.cgi', 'exec=discovery&arg0=' + discovery_mode + '&arg1=' + discovery_target+ '&arg2=' + clear2 + '&arg3=' + discovery_limit, gc_time, '', 1);
 discovery.refresh = function() { }
 /* DISCOVERY-END */
 
@@ -392,10 +396,10 @@ dg.populate = function() {
 
 		if ((e.mac.match(/^(..):(..):(..)/)) && e.proto != 'pppoe' && e.proto != 'pptp' && e.proto != 'l2tp') {
 			b = '<a href="javascript:searchOUI(\''+RegExp.$1+'-'+RegExp.$2+'-'+RegExp.$3+'\','+i+')" title="OUI Search">'+e.mac+'<\/a><div style="display:none" id="gW_'+i+'">&nbsp; <img src="spin.gif" alt="" style="vertical-align:middle"><\/div>'+
-			    '<br><small class="pics">'+
-			    '<a href="javascript:addStatic('+i+')" title="DHCP Reservation">[DR]<\/a> '+
-			    '<a href="javascript:addbwlimit('+i+')" title="BW Limiter">[BWL]<\/a> '+
-			    '<a href="javascript:addRestrict('+i+')" title="Access Restriction">[AR]<\/a>';
+				'<br><small class="pics">'+
+				'<a href="javascript:addStatic('+i+')" title="DHCP Reservation">[DR]<\/a> '+
+				'<a href="javascript:addbwlimit('+i+')" title="BW Limiter">[BWL]<\/a> '+
+				'<a href="javascript:addRestrict('+i+')" title="Access Restriction">[AR]<\/a>';
 
 			if (e.rssi != '')
 				b += ' <a href="javascript:addWF('+i+')" title="Wireless Filter">[WLF]<\/a>';
@@ -457,7 +461,7 @@ dg.populate = function() {
 			}
 			else
 /* USB-END */
-			     if (e.rssi != 1) {
+			if (e.rssi != 1) {
 				f = '<img src="eth.gif"'+c+' alt="" title="Ethernet">';
 				e.media = 4;
 			}
@@ -472,8 +476,8 @@ dg.populate = function() {
 		}
 
 		this.insert(-1, e, [ a, '<div id="media_'+i+'">'+f+'<\/div>', b, (e.mode == 'wds' ? '' : e.ip), e.name, (e.rssi < 0 ? e.rssi+' <small>dBm<\/small>' : ''),
-		                     (e.qual < 0 ? '' : '<small>'+e.qual+'<\/small> <img src="bar'+MIN(MAX(Math.floor(e.qual / 12), 1), 6)+'.gif" id="bar_'+i+'" alt="">'),
-		                     e.txrx, e.lease], false);
+				(e.qual < 0 ? '' : '<small>'+e.qual+'<\/small> <img src="bar'+MIN(MAX(Math.floor(e.qual / 12), 1), 6)+'.gif" id="bar_'+i+'" alt="">'),
+				e.txrx, e.lease], false);
 	}
 }
 
@@ -651,16 +655,18 @@ function tick() {
 	var clock = E('wait');
 	var spin = E('spin');
 
-	if (ref.running && discovery_mode != 'off' && E('refresh-button').value == 'Stop' && E('refresh-time').value != 0) {
-		elem.setInnerHTML(clock, wait+' sec');
+	if (ref.running && discovery_mode !== 'off' && E('refresh-button').value == 'Stop' && E('refresh-time').value != 0) {
+		elem.setInnerHTML(clock, wait + ' sec');
 		clock.style.display = 'inline-block';
 		spin.style.display = 'inline';
 
-		if (wait-- <= 0) {
+		if (wait <= 0) {
+			discovery.initPage(0, gc_time);
 			wait = gc_time;
-			clearTimeout(time_o);
 		}
-
+		else {
+			wait--;
+		}
 		time_o = setTimeout(tick, 1000);
 	}
 	else {
@@ -672,17 +678,24 @@ function tick() {
 }
 
 function verifyFields(f, c) {
-	if (discovery.running)
-		discovery.stop();
-
+	if (discovery.running) discovery.stop();
+	discovery_clear = E('_discovery_clear').checked ? 1 : 0;
+	cookie.set(cprefix + '_discovery_clear', discovery_clear);
+	clear2 = (discovery_clear === 1) ? 'clear' : '';
+	discovery_limit = E('_discovery_limit').value;
+	cookie.set(cprefix+'_discovery_limit', discovery_limit);
+	discovery_target = E('_discovery_target').value;
+	cookie.set(cprefix+'_discovery_target', discovery_target);
 	discovery_mode = E('_discovery_mode').value;
-	cookie.set(cprefix+'_discovery', discovery_mode);
-	discovery = new TomatoRefresh('update.cgi', 'exec=discovery&arg0='+discovery_mode, gc_time, '', 1);
-	discovery.refresh = function() { }
+	cookie.set(cprefix+'_discovery_mode', discovery_mode);
+	discovery = new TomatoRefresh('update.cgi', 'exec=discovery&arg0=' + discovery_mode + '&arg1=' + discovery_target + '&arg2=' + clear2 + '&arg3=' + discovery_limit, gc_time, '', 1);
+	discovery.refresh = function() { 
+	}
+	
 	if (ref.running)
 		discovery.initPage(0, gc_time);
 
-	if (discovery_mode != 'off') {
+	if (discovery_mode !== 'off') {
 		wait = gc_time;
 		clearTimeout(time_o);
 		tick();
@@ -717,8 +730,10 @@ function earlyInit() {
 			setNoiseBar(uidx, wlnoise[uidx]);
 		}
 	}
-
 	dg.setup();
+/* DISCOVERY-BEGIN */
+	E('_discovery_clear').checked = (discovery_clear === 1);
+/* DISCOVERY-END */
 }
 
 function init() {
@@ -760,13 +775,18 @@ function init() {
 			if (nvram['wl'+u+'_radio'] == 1 && wl_sunit(uidx) < 0)
 					f.push( { title: '<span id="nf'+u+'" title="Noise Floor"><b>Noise<\/b> '+wl_display_ifname(uidx)+'&nbsp;<b>:<\/b><\/span>', prefix: '<span id="noiseimg_'+uidx+'"><\/span>&nbsp;<span id="noise'+uidx+'">', custom: wlnoise[uidx], suffix: '<\/span>&nbsp;<small>dBm<\/small>' } );
 		}
-/* DISCOVERY-BEGIN */
-		f.push(
-			null,
-			{ title: 'Network Discovery mode', name: 'discovery_mode', type: 'select', options: [['off','off'],['arping','arping (preferred)'],['traceroute','traceroute']], suffix: '&nbsp; <img src="spin.gif" alt="" id="spin"><div id="wait"><\/div>', value: discovery_mode }
-		);
-/* DISCOVERY-END */
 		createFieldTable('', f);
+/* DISCOVERY-BEGIN */
+		var f = [];
+		f.push(
+			{ title: 'Sanitize results', name: 'discovery_clear', type: 'checkbox', value: 'clear', checked: (discovery_clear === 1) ? 'checked' : '' },
+			{ title: 'Max Probes', name: 'discovery_limit', type: 'text', maxlen: 3, size: 3, value: discovery_limit,  placeholder: '60', suffix: '<\/span>&nbsp;<small> 5 - 200<\/small>' },	
+			{ title: 'Scan Target', name: 'discovery_target', type: 'select', options: [['lan','LANs *'],['wan','WANs'],['both','LANs & WANs']], value: discovery_target },
+			{ title: 'Scan Mode', name: 'discovery_mode', type: 'select', options: [['off','Off *'],['arping','arping (preferred)'],['traceroute','traceroute'],['nc','netcat'],['all','all (round-robin)']], suffix: '&nbsp; <img src="spin.gif" alt="" id="spin"><div id="wait"></div>', value: discovery_mode }
+		);
+		W('<p><div class="section-title">Network Discovery</div>');
+		createFieldTable('', f);
+/* DISCOVERY-END */
 	</script>
 </div>
 


### PR DESCRIPTION
Changelog:
- Code cleaning and optimisation for speed
- Allows to scan LAN as well as WAN interfaces
- Introduces a limit of minimum netmask /22 (e.g. /21 is ignored)
- Adds netcat as a scanning method
- Adds "all" method (round-robin)
- It now excludes existing IPs from the list of scan targets
- Adds Sanitize option to clear up the ip neighbouring table
- Allows to define the aggressiveness of the scan via the Max Probes option (5-200, def 60)
- A change of parameter triggers an automatic  discovery kill + new discovery on new parameters
- Adds control to prevent overlapping discoveries if no parameters have changed
- Support for debug (/tmp/discovery.debug) setting manually "nvram set discovery_debug=1"

Performance:
LAN+WAN in arping + 60 sessions + clear:
~=10 seconds on RT-AC1900P
~=20 seconds on RT-N16

Wiki page of reference:
https://wiki.freshtomato.org/doku.php/status-devices