### PR TITLE
libshared: Default DSCP fix to off.

### DIFF
--- a/release/src-rt-6.x.4708/router/shared/defaults.c
+++ b/release/src-rt-6.x.4708/router/shared/defaults.c
@@ -986,7 +986,7 @@ struct nvram_tuple router_defaults[] = {
 	{ "udpxy_wanface",		""				, 0 },	/* alternative wanface */
 #endif /* TCONFIG_PROXY */
 	{ "ne_syncookies",		"0"				, 0 },	/* tcp_syncookies */
-	{ "DSCP_fix_enable",		"1"				, 0 },	/* Comacst DSCP fix */
+	{ "DSCP_fix_enable",		"0"				, 0 },	/* Comacst DSCP fix */
 	{ "ne_snat",			"0"				, 0 },	/* use SNAT instead of MASQUERADE */
 	{ "wan_dhcp_pass",		"0"				, 0 },	/* allow DHCP responses */
 	{ "fw_blackhole",		"1"				, 0 },	/* MTU black hole detection */


### PR DESCRIPTION
Looks like comacast fixed this issue back in 2023.
https://forum.openwrt.org/t/cake-w-dscps-cake-qos-simple/147087/252