### PR TITLE
GUI: basic-time.asp - NTP Client added 4th placeholder field for Custom upstream server.

### DIFF
--- a/release/src-rt-6.x.4708/router/www/basic-time.asp
+++ b/release/src-rt-6.x.4708/router/www/basic-time.asp
@@ -79,11 +79,11 @@ function verifyFields(focused, quiet) {
 	elem.display(PR('_f_ntp_server'), b);
 
 	a = (E('_f_ntp_server').value == 'custom');
-	elem.display(PR('_f_ntp_1'), PR('_f_ntp_2'), PR('_f_ntp_3'), a && b);
+	elem.display(PR('_f_ntp_1'), PR('_f_ntp_2'), PR('_f_ntp_3'), PR('_f_ntp_4'), a && b);
 	elem.display(PR('ntp-preset'), !a && b);
 
 	if (a) {
-		if ((E('_f_ntp_1').value == '') && (E('_f_ntp_2').value == '') && ((E('_f_ntp_3').value == ''))) {
+		if ((E('_f_ntp_1').value == '') && (E('_f_ntp_2').value == '') && (E('_f_ntp_3').value == '') && (E('_f_ntp_4').value == '')) {
 			ferror.set('_f_ntp_1', 'At least one NTP server is required', quiet);
 			return 0;
 		}
@@ -111,7 +111,7 @@ function save() {
 	if (fom._f_ntp_server.value != 'custom')
 		fom.ntp_server.value = ntpString(fom._f_ntp_server.value);
 	else {
-		a = [fom.f_ntp_1.value, fom.f_ntp_2.value, fom.f_ntp_3.value];
+		a = [fom.f_ntp_1.value, fom.f_ntp_2.value, fom.f_ntp_3.value, fom.f_ntp_4.value];
 		for (i = 0; i < a.length; ) {
 			if (a[i] == '')
 				a.splice(i, 1);
@@ -264,7 +264,8 @@ function init() {
 			{ title: '&nbsp;', text: '<small><span id="ntp-preset">xx<\/span><\/small>', hidden: 1 },
 			{ title: '', name: 'f_ntp_1', type: 'text', maxlen: 48, size: 34, value: ntp[0] || 'pool.ntp.org', hidden: 1 },
 			{ title: '', name: 'f_ntp_2', type: 'text', maxlen: 48, size: 34, value: ntp[1] || '', hidden: 1 },
-			{ title: '', name: 'f_ntp_3', type: 'text', maxlen: 48, size: 34, value: ntp[2] || '', hidden: 1 }
+			{ title: '', name: 'f_ntp_3', type: 'text', maxlen: 48, size: 34, value: ntp[2] || '', hidden: 1 },
+			{ title: '', name: 'f_ntp_4', type: 'text', maxlen: 48, size: 34, value: ntp[3] || '', hidden: 1 }
 		]);
 	</script>
 </div>


### PR DESCRIPTION
The expectation is to pull time from a NTP server/IP within the LAN if WAN is not available

Looks like the .asp is the only place that needs adjustment as I'm able to:
```
$ nvram set ntp_server='0.us.pool.ntp.org 1.us.pool.ntp.org 2.us.pool.ntp.org 192.168.0.14'
$ nvram commit
$ service ntpd restart
```
and properly setups **ntp.conf**:
```
$ cat /etc/ntp.conf

server 0.us.pool.ntp.org
server 1.us.pool.ntp.org
server 2.us.pool.ntp.org
server 192.168.0.14
```
