### PR TITLE
- httpd: misc.c: Issue with CPU Usage NaN% in Status Overview page

### DIFF
--- a/release/src-rt-6.x.4708/router/httpd/misc.c
+++ b/release/src-rt-6.x.4708/router/httpd/misc.c
@@ -507,7 +507,7 @@ mtd1: 007d0000 00010000 "linux"
 #ifdef TCONFIG_BCMARM
 void asp_jiffies(int argc, char **argv)
 {
-	char sa[64];
+	char sa[128];
 	FILE *a;
 	char *e = NULL;
 	char *f= NULL;
@@ -602,7 +602,7 @@ void asp_sysinfo(int argc, char **argv)
 
 #ifdef TCONFIG_BCMARM
 	char cputemp[8];
-	char sa[64];
+	char sa[128];
 	FILE *a;
 	char *e = NULL;
 	char *f= NULL;


### PR DESCRIPTION
Few days after FT router reboots, everything seems to work fine with the CPU Usage % metrics in Status Overview page.
After weeks at router full workload capacity, the percentage turns into a NaN%... "inconsistently"⚠️

https://www.linksysinfo.org/index.php?threads/issue-with-cpu-usage-nan-in-status-overview-page-a-walkthrough-arm-asus-rt-ac3200.79175/post-358580