### PR TITLE
GUI: Advanced: VLAN: fix link in Notes (close #81)

### DIFF
--- a/release/src-rt-6.x.4708/router/www/advanced-vlan.asp
+++ b/release/src-rt-6.x.4708/router/www/advanced-vlan.asp
@@ -1107,7 +1107,7 @@ function init() {
 
 	<div class="section-title">Notes <small><i><a href="javascript:toggleVisibility(cprefix,'notes');" id="toggleLink-notes"><span id="sesdiv_notes_showhide">(Show)</span></a></i></small></div>
 	<div class="section" id="sesdiv_notes" style="display:none">
-		<div>If you notice that the order of the LAN Ports are incorrectly mapped, <a href="http://www.linksysinfo.org/index.php?threads/can-vlan-gui-port-order-be-corrected.70160/#post-247634/"> <b>please follow these instructions to get it corrected.</b></a></div>
+		<div>If you notice that the order of the LAN Ports are incorrectly mapped, <a href="http://www.linksysinfo.org/index.php?threads/can-vlan-gui-port-order-be-corrected.70160/#post-247634"> <b>please follow these instructions to get it corrected.</b></a></div>
 		<br>
 		<i>VLAN Ethernet:</i> Assignments of physical ethernet interfaces to predefined LAN bridges.<br>
 		<ul>


### PR DESCRIPTION
I don't know why, but the link is at 2 places in the code... And I still get the wrong one in 2025.3.

Line 1065 and 1110

Commit ec25396742f6f17b43de069fedc2fca8707f8c0f only corrected the link at line 1065. 

This correct the link at line 1110.

See issue 81 for more details.