### PR TITLE
tomato.css - improved to print and printscreen in dark-mode

### DIFF
--- a/release/src-rt-6.x.4708/router/www/tomato.css
+++ b/release/src-rt-6.x.4708/router/www/tomato.css
@@ -38,9 +38,20 @@ body {
 	position: relative;
 	height: 100%;
 	width: 100%;
-	filter: brightness(80%) sepia(10%);
 	background-color: black;
 	background-image: none;
+}
+
+@media screen {
+	.alt-mode {
+		filter: brightness(80%) sepia(10%);
+	}
+}
+
+@media print {
+	.alt-mode {
+		filter: none;
+	}
 }
 
 a {


### PR DESCRIPTION
This change improves the quality of printscreen and physical prints while the GUI is in .alt-mode (a.k.a. dark mode) and the brightness/sepia filter is applied.