### PR TITLE
GUI: status-overview.asp - Only displaying unsecured WiFi warning in AP mode

### DIFF
--- a/release/src-rt-6.x.4708/router/www/status-overview.asp
+++ b/release/src-rt-6.x.4708/router/www/status-overview.asp
@@ -354,7 +354,7 @@ function show() {
 	for (var uidx = 0; uidx < wl_ifaces.length; ++uidx) {
 		if (wl_sunit(uidx) < 0) {
 			/* warn against unsecured wifi */
-			if (nvram['wl'+wl_fface(uidx)+'_radio'] == '1' && wlstats[uidx].radio && nvram['wl'+wl_fface(uidx)+'_net_mode'] != 'disabled' && nvram['wl'+wl_fface(uidx)+'_security_mode'] == 'disabled')
+			if (nvram['wl'+wl_fface(uidx)+'_radio'] == '1' && wlstats[uidx].radio && nvram['wl'+wl_fface(uidx)+'_net_mode'] != 'disabled' && nvram['wl'+wl_fface(uidx)+'_security_mode'] == 'disabled' && nvram['wl'+wl_fface(uidx)+'_mode'] == 'ap')
 				E('status-wifiwarn').style.display = 'block';
 			else
 				E('status-wifiwarn').style.display = 'none';


### PR DESCRIPTION
As reported here:

https://www.linksysinfo.org/index.php?threads/disable-the-overview-wifi-security-disabled-warning-when-the-relevant-interface-is-in-wireless-client-mode.79444/