### PR TITLE
Add Bridge Gateway Isolation + UI (IPv4 only atm), IPv6 bridge isolation, and IPv6-aware advanced-access.asp

### DIFF
--- a/release/src-rt-6.x.4708/router/httpd/tomato.c
+++ b/release/src-rt-6.x.4708/router/httpd/tomato.c
@@ -651,6 +651,7 @@ static const nvset_t nvset_list[] = {
 #endif /* TCONFIG_PROXY */
 	{ "block_loopback",		V_01				},
 	{ "nf_loopback",		V_NUM				},
+	{ "fw_strict_input",		V_01				},
 	{ "ne_syncookies",		V_01				},
 	{ "DSCP_fix_enable",		V_01				},
 	{ "ne_snat",			V_01				},

--- a/release/src-rt-6.x.4708/router/rc/firewall.c
+++ b/release/src-rt-6.x.4708/router/rc/firewall.c
@@ -945,6 +945,10 @@ static void filter_input(void)
 	char *hit;
 	int i, n;
 	char *p, *c;
+	char lanN_ifname[] = "lanXX_ifname";
+	char lanN_ifname2[] = "lanXX_ifname";
+	char lanN_ipaddr[] = "lanXX_ipaddr";
+	char br, br2;
 
 #ifdef TCONFIG_BCMARM
 	/* 3 for filter */
@@ -1005,9 +1009,41 @@ static void filter_input(void)
 	}
 #endif
 
-	ipt_write("-A INPUT -i lo -j ACCEPT\n"
-	          "-A INPUT -i %s -j ACCEPT\n",
-	          lanface[0]);
+	ipt_write("-A INPUT -i lo -j ACCEPT\n");
+
+	if (nvram_get_int("fw_strict_input")) {
+		for (br = 0; br < BRIDGE_COUNT; br++) {
+			char bridge[2] = "0";
+			if (br != 0)
+				bridge[0] += br;
+			else
+				memset(bridge, 0, sizeof(bridge));
+
+			snprintf(lanN_ifname, sizeof(lanN_ifname), "lan%s_ifname", bridge);
+			if (strncmp(nvram_safe_get(lanN_ifname), "br", 2) == 0) {
+				for (br2 = 0; br2 < BRIDGE_COUNT; br2++) {
+					if (br == br2)
+						continue;
+
+					char bridge2[2] = "0";
+					if (br2 != 0)
+						bridge2[0] += br2;
+					else
+						memset(bridge2, 0, sizeof(bridge2));
+
+					snprintf(lanN_ifname2, sizeof(lanN_ifname2), "lan%s_ifname", bridge2);
+					if (strncmp(nvram_safe_get(lanN_ifname2), "br", 2) == 0) {
+
+						snprintf(lanN_ipaddr, sizeof(lanN_ipaddr), "lan%s_ipaddr", bridge2);
+
+						ipt_write("-A INPUT -i %s -d %s -j DROP\n", nvram_safe_get(lanN_ifname), nvram_safe_get(lanN_ipaddr));
+					}
+				}
+			}
+		}
+	}
+
+	ipt_write("-A INPUT -i %s -j ACCEPT\n", lanface[0]);
 
 	for (i = 1 ; i < BRIDGE_COUNT; i++) {
 		if (strcmp(lanface[i], "") != 0)
@@ -1137,8 +1173,8 @@ static void filter_input(void)
 
 static void filter_forward(void)
 {
-	char dst[64];
-	char src[64];
+	char dst[128];
+	char src[128];
 	char buffer[512], dmz1[32], dmz2[32];
 	char *p, *c;
 	char br, br2;
@@ -1178,15 +1214,16 @@ static void filter_forward(void)
 			 * 5.6.7.8 = dst addr
 			 * desc = desc
 			 */
+			int src_f, dst_f;
+
 			if ((vstrsep(b, "<", &d, &sbr, &saddr, &dbr, &daddr, &desc) < 6) || (*d != '1'))
 				continue;
-			if (!ipt_addr(src, sizeof(src), saddr, "src", (IPT_V4 | IPT_V6), 0, "LAN access", desc))
+			if (!(src_f = ipt_addr(src, sizeof(src), saddr, "src", (IPT_V4 | IPT_V6), 0, "LAN access", desc)))
 				continue;
-			if (!ipt_addr(dst, sizeof(dst), daddr, "dst", (IPT_V4 | IPT_V6), 0, "LAN access", desc))
+			if (!(dst_f = ipt_addr(dst, sizeof(dst), daddr, "dst", (IPT_V4 | IPT_V6), 0, "LAN access", desc)))
 				continue;
 
-			/* ipv4 only */
-			ipt_write("-A FORWARD -i %s%s -o %s%s %s %s -j ACCEPT\n", "br", sbr, "br", dbr, src, dst);
+			ip46t_flagged_write(ipv6_enabled, src_f & dst_f, "-A FORWARD -i %s%s -o %s%s %s %s -j ACCEPT\n", "br", sbr, "br", dbr, src, dst);
 
 			if ((strcmp(src, "") == 0) && (strcmp(dst, "") == 0))
 				lanAccess[((*sbr - 48) + (*dbr - 48) * BRIDGE_COUNT)] = '1';
@@ -1249,7 +1286,7 @@ static void filter_forward(void)
 				snprintf(lanN_ifname2, sizeof(lanN_ifname2), "lan%s_ifname", bridge2);
 
 				if (strncmp(nvram_safe_get(lanN_ifname2), "br", 2) == 0)
-					ipt_write("-A FORWARD -i %s -o %s -j DROP\n", nvram_safe_get(lanN_ifname), nvram_safe_get(lanN_ifname2));
+					ip46t_write(ipv6_enabled, "-A FORWARD -i %s -o %s -j DROP\n", nvram_safe_get(lanN_ifname), nvram_safe_get(lanN_ifname2));
 			}
 //			ip46t_write(ipv6_enabled, "-A FORWARD -i %s -j %s\n", nvram_safe_get(lanN_ifname), chain_out_accept);
 		}

--- a/release/src-rt-6.x.4708/router/shared/defaults.c
+++ b/release/src-rt-6.x.4708/router/shared/defaults.c
@@ -969,6 +969,7 @@ struct nvram_tuple router_defaults[] = {
 
 /* advanced-firewall */
 	{ "nf_loopback",		"0"				, 0 },
+	{ "fw_strict_input",		"1"				, 0 },	/* block inter-bridge access to router IPs */
 	{ "block_wan",			"1"				, 0 },	/* block inbound icmp */
 	{ "block_wan_limit",		"1"				, 0 },
 	{ "block_wan_limit_icmp",	"3"				, 0 },

--- a/release/src-rt-6.x.4708/router/www/advanced-access.asp
+++ b/release/src-rt-6.x.4708/router/www/advanced-access.asp
@@ -28,9 +28,9 @@ la.setup = function() {
 	this.init('la-grid', 'sort', 50, [
 	{ type: 'checkbox', prefix: '<div class="centered">', suffix: '<\/div>' },
 	{ type: 'select', options: [[0,'LAN0 (br0)'],[1,'LAN1 (br1)'],[2,'LAN2 (br2)'],[3,'LAN3 (br3)']], prefix: '<div class="centered">', suffix: '<\/div>' },
-	{ type: 'text', maxlen: 32 },
+	{ type: 'text', maxlen: 80 },
 	{ type: 'select', options: [[0,'LAN0 (br0)'],[1,'LAN1 (br1)'],[2,'LAN2 (br2)'],[3,'LAN3 (br3)']], prefix: '<div class="centered">', suffix: '<\/div>' },
-	{ type: 'text', maxlen: 32 },
+	{ type: 'text', maxlen: 80 },
 	{ type: 'text', maxlen: 32 }]);
 	this.headerSet(['On','Src','Src Address','Dst','Dst Address','Description']);
 
@@ -96,6 +96,15 @@ la.resetNewEditor = function() {
 	ferror.clearAll(fields.getAll(this.newEditor));
 }
 
+/* returns: 1=IPv4, 2=IPv6, 3=both (empty or domain) */
+function getAddrFamily(addr) {
+	if (!addr || addr.trim().length == 0) return 3;
+	addr = addr.trim();
+	if (addr.indexOf(':') !== -1) return 2;
+	if (/^[\d.\/-]+$/.test(addr)) return 1;
+	return 3;
+}
+
 la.verifyFields = function(row, quiet) {
 	var f = fields.getAll(row);
 
@@ -119,8 +128,17 @@ la.verifyFields = function(row, quiet) {
 	f[2].value = f[2].value.trim();
 	f[4].value = f[4].value.trim();
 
-	if ((f[2].value.length) && (!v_iptaddr(f[2], quiet))) return 0;
-	if ((f[4].value.length) && (!v_iptaddr(f[4], quiet))) return 0;
+	if ((f[2].value.length) && (!_v_iptaddr(f[2], quiet, 0, 1, 1))) return 0;
+	if ((f[4].value.length) && (!_v_iptaddr(f[4], quiet, 0, 1, 1))) return 0;
+
+	var srcFamily = getAddrFamily(f[2].value);
+	var dstFamily = getAddrFamily(f[4].value);
+	if ((srcFamily == 1 && dstFamily == 2) || (srcFamily == 2 && dstFamily == 1)) {
+		var m = 'Source and Destination addresses must be the same IP version (both IPv4 or both IPv6)';
+		ferror.set(f[2], m, quiet);
+		ferror.set(f[4], m, quiet);
+		return 0;
+	}
 
 	ferror.clear(f[2]);
 	ferror.clear(f[4]);

--- a/release/src-rt-6.x.4708/router/www/advanced-firewall.asp
+++ b/release/src-rt-6.x.4708/router/www/advanced-firewall.asp
@@ -22,7 +22,7 @@
 
 <script>
 
-//	<% nvram("block_wan,block_wan_limit,block_wan_limit_icmp,nf_loopback,ne_syncookies,DSCP_fix_enable,multicast_pass,multicast_lan,multicast_quickleave,multicast_custom,lan_ifname,udpxy_enable,udpxy_lan,udpxy_stats,udpxy_clients,udpxy_port,udpxy_wanface,ne_snat,emf_enable,force_igmpv2,wan_dhcp_pass,fw_blackhole"); %>
+//	<% nvram("block_wan,block_wan_limit,block_wan_limit_icmp,nf_loopback,fw_strict_input,ne_syncookies,DSCP_fix_enable,multicast_pass,multicast_lan,multicast_quickleave,multicast_custom,lan_ifname,udpxy_enable,udpxy_lan,udpxy_stats,udpxy_clients,udpxy_port,udpxy_wanface,ne_snat,emf_enable,force_igmpv2,wan_dhcp_pass,fw_blackhole"); %>
 
 var cprefix = 'advanced_firewall';
 
@@ -222,7 +222,9 @@ function init() {
 			{ title: 'Enable DSCP Fix', name: 'f_DSCP_fix_enable', type: 'checkbox', value: nvram.DSCP_fix_enable != '0', suffix: ' &nbsp;<small>fixes Comcast incorrect DSCP<\/small>' },
 			null,
 			{ title: 'Allow DHCP spoofing', name: 'f_wan_dhcp_pass', type: 'checkbox', value: nvram.wan_dhcp_pass == 1 },
-			{ title: 'Smart MTU black hole detection', name: 'f_fw_blackhole', type: 'checkbox', value: nvram.fw_blackhole == 1 }
+			{ title: 'Smart MTU black hole detection', name: 'f_fw_blackhole', type: 'checkbox', value: nvram.fw_blackhole == 1 },
+			null,
+			{ title: 'Bridge Gateway Isolation', name: 'fw_strict_input', type: 'select', options: [[0,'Disabled'],[1,'Enabled']], value: nvram.fw_strict_input, suffix: ' &nbsp;<small>Blocks devices from accessing gateway IPs on other bridges<\/small>' }
 		]);
 	</script>
 </div>


### PR DESCRIPTION
Bridge Gateway Isolation blocks devices from accessing gateway IPs on other bridges. This prevents devices gaining access to services only enabled for other bridges/lans. (ie samba, media server etc)
Currently IPv4 only as it relies on network settings for all bridges to be stored in nvram.

IPv6 bridge isolation prevents cross bridge IPv6 communication between clients like has existing for a long time with IPv4.