### PR TITLE
nvram: new fname variable to store FW filename during the flashing process

### DIFF
--- a/release/src-rt-6.x.4708/router/rc/init.c
+++ b/release/src-rt-6.x.4708/router/rc/init.c
@@ -120,6 +120,7 @@ static void restore_defaults(void)
 
 	nvram_set("os_version", tomato_version);
 	nvram_set("os_date", tomato_buildtime);
+	init_firmware_filename();
 
 #if defined(TCONFIG_BLINK) || defined(TCONFIG_BCMARM) /* RT-N+ */
 	/* Adjust et and wl thresh value after reset (for wifi-driver and et_linux.c) */
@@ -857,6 +858,40 @@ static int wlshutdown_ethx_rtac5300(void)
 	return dirty;
 }
 #endif /* TCONFIG_AC5300 */
+
+static void init_firmware_filename(void)
+{
+	char *model, *os_ver;
+	char ver[16], branch[16], build[64];
+	char fname[256];
+
+	/* Get model from odmpid (clean model name without manufacturer prefix) */
+	model = nvram_safe_get("odmpid");
+	if (!*model)
+		model = nvram_safe_get("productid");
+	if (!*model)
+		model = nvram_safe_get("model");
+
+	/* Parse os_version: "2025.5 K26ARM USB AIO-64K" */
+	os_ver = nvram_safe_get("os_version");
+	if (sscanf(os_ver, "%15s %15s %*s %63s", ver, branch, build) == 3) {
+		/* Construct filename matching build.mak pattern:
+		 * freshtomato-MODEL-BRANCH-VERSION-BUILD.trx */
+		snprintf(fname, sizeof(fname), "freshtomato-%s-%s-%s-%s.trx",
+			model, branch, ver, build);
+	}
+	else {
+		/* Fallback if os_version is malformed (should never happen in normal builds) */
+		snprintf(fname, sizeof(fname), "freshtomato-%s-unknown-unknown-unknown.trx", model);
+		syslog(LOG_WARNING, "Failed to parse os_version: %s", os_ver);
+	}
+
+	/* Only update if filename changed */
+	if (!nvram_match("fname", fname)) {
+		nvram_set("fname", fname);
+		syslog(LOG_INFO, "Firmware filename: %s", fname);
+	}
+}
 
 static void init_lan_hwaddr(void)
 {

--- a/release/src-rt-6.x.4708/router/shared/defaults.c
+++ b/release/src-rt-6.x.4708/router/shared/defaults.c
@@ -338,6 +338,7 @@ struct nvram_tuple bsd_defaults[] = {
 
 struct nvram_tuple router_defaults[] = {
 	{ "restore_defaults",		"0"				, 0 },	/* Set to 0 to not restore defaults on boot */
+	{ "fname",				""				, 0 },	/* Populate filename used during flashing */
 
 	/* LAN H/W parameters */
 	{ "lan_hwnames",		""				, 0 },	/* LAN driver names (e.g. et0) */

--- a/release/src-rt-6.x.4708/router/www/admin-upgrade.asp
+++ b/release/src-rt-6.x.4708/router/www/admin-upgrade.asp
@@ -18,7 +18,7 @@
 
 <script>
 
-//	<% nvram("jffs2_on,jffs2_auto_unmount,remote_upgrade"); %>
+//	<% nvram("jffs2_on,jffs2_auto_unmount,remote_upgrade,fname"); %>
 
 //	<% sysinfo(); %>
 
@@ -61,6 +61,7 @@ function upgrade() {
 function earlyInit() {
 	E('upgradenotice').style.display = (nvram.remote_upgrade == 1 ? 'none' : 'block');
 	E('afu-size').innerHTML = '&nbsp; '+scaleSize(sysinfo.totalfreeram)+'&nbsp; <small>(approx. size that can be buffered completely in RAM)<\/small>';
+	E('afu-fname').innerHTML = '&nbsp; '+nvram.fname;
 /* JFFS2-BEGIN */
 	if (nvram.jffs2_on != 0 && nvram.jffs2_auto_unmount == 0) {
 		E('afu-warn').style.display = 'block';
@@ -109,6 +110,10 @@ function earlyInit() {
 				<td>Current Version:</td>
 				<td>&nbsp; <% version(1); %></td>
 			</tr>
+			<tr>
+				<td>Current Filename:</td>
+				<td id="afu-fname"></td>
+			</tr>			</tr>
 			<tr>
 				<td>Free Memory:</td>
 				<td id="afu-size"></td>


### PR DESCRIPTION
Using the identical logic used by the build.mak this new init_firmware_filename() function identifies the output filename as produced by the build.mak recipe and stores it into a new **fname** nvram variable.

```
root@sparrow:/# nvram get fname
freshtomato-RT-AC1900P-K26ARM-2025.5-AIO-64K.trx

```

This variable is forcedly overwritten at each flashing (only) with the idea to always have the current firmware filename made available to the system.

<img width="711" height="105" alt="ne6nSluZr3" src="https://github.com/user-attachments/assets/b22db5c1-8a61-4056-9a4f-27938af12ba6" />
