### PR TITLE
GUI: advanced-misc.asp - Ethernet Port Health

### DIFF
--- a/release/src-rt-6.x.4708/router/others/Makefile
+++ b/release/src-rt-6.x.4708/router/others/Makefile
@@ -8,6 +8,9 @@ install:
 	install -d $(INSTALLDIR)/usr/bin
 	install -d $(INSTALLDIR)/lib
 
+# Port health monitor/recover script
+	install -m 0700 porthealth.sh $(INSTALLDIR)/usr/sbin/porthealth.sh
+
 ifeq ($(TCONFIG_USB),y)
 # Optware perl symlink
 	install -d $(INSTALLDIR)/usr/bin

--- a/release/src-rt-6.x.4708/router/others/porthealth.sh
+++ b/release/src-rt-6.x.4708/router/others/porthealth.sh
@@ -1,0 +1,271 @@
+#!/bin/sh
+# porthealth v3.0 - rs232
+MODE=${1:-help}
+BASE_RATE=30
+HOLD_TIME=180
+CACHE_TIMEOUT=1800
+IF_TYPE=l
+for arg in "$@"; do
+	case "$arg" in
+		max=*) BASE_RATE=${arg#max=};;
+		hold=*) HOLD_TIME=${arg#hold=};;
+		cache=*) CACHE_TIMEOUT=${arg#cache=};;
+		if=*) IF_TYPE=${arg#if=};;
+		[0-9]*) BASE_RATE=$arg;;
+	esac
+done
+
+case "$MODE" in
+	help)
+		cat <<'EOF'
+Usage: porthealth.sh [mode] [options]
+
+Modes:
+  monitor  : logs a warning when threshold is exceeded.
+
+  recover  : a) resets the interface to its maximum capabilities e.g. 1000FD
+  	     b) between each change it re-evaluates (enforcing a hold time);
+	     c) step down link speed/duplex via robocfg;
+	     d) disable if still failing at lowest.
+
+  disable  : just log and disable the guilty port.
+
+  help     : (default) show this help message.
+
+Options:
+  max=N    : max acceptable errors per port per minute (default 30)
+  hold=N   : recovery hold time before scale-down in seconds (default 180)
+  cache=N  : port list cache timeout in seconds (default 1800)
+  if=TYPE  : monitor interface type - l='LANs (default)', w='WANs', a='LANs & WANs'
+
+Examples:
+  porthealth.sh monitor
+  porthealth.sh recover max=80 hold=300 if=l
+  porthealth.sh disable max=100 if=a
+
+EOF
+		exit 0
+		;;
+esac
+
+STATE_DIR=/tmp/porthealth
+COUNTERS=$STATE_DIR/counters
+ERROR_SUM=$STATE_DIR/errors.total
+RECOVER_STATE=$STATE_DIR/recover.state   # recover state: "ethX:idx:baseline:action_time"
+N=$(date +%s)
+
+if [ ! -d "$STATE_DIR" ]; then
+	mkdir -p "$STATE_DIR"
+fi
+
+log_warn() { logger -p user.warn "porthealth: $*"; }
+log_err()  { logger -p user.err  "porthealth: $*"; }
+
+get_mtime() {
+	[ ! -f "$1" ] && return 1
+	res=$(stat -c %Y "$1" 2>/dev/null)
+	if [ -n "$res" ]; then
+		echo "$res"
+		return 0
+	fi
+	date -r "$1" +%s 2>/dev/null
+}
+
+# robocfg speed steps (high -> low)
+# NOTE: tokens must match your robocfg build (common: 1000FD 1000HD 100FD 100HD 10FD 10HD)
+STEPS="1000FD 1000HD 100FD 100HD 10FD 10HD"
+
+# Threshold calc (errors per elapsed minutes)
+if [ -f "$ERROR_SUM" ]; then
+	last_time=$(get_mtime "$ERROR_SUM")
+else
+	last_time=""
+	logger "porthealth: init"
+fi
+[ -z "$last_time" ] && last_time=$N
+elapsed=$((N - last_time))
+[ "$elapsed" -lt 1 ] && elapsed=60
+R=$((BASE_RATE * elapsed / 60))
+[ "$R" -lt 1 ] && R=1
+
+# Helpers to read/write recover state (kept small; only used in recover mode)
+state_get() {
+	# prints: idx baseline action_time
+	awk -F: -v k="$1" 'BEGIN{idx=""} $1==k {print $2" "$3" "$4; exit}' "$RECOVER_STATE" 2>/dev/null
+}
+state_set() {
+	# $1=if $2=idx $3=baseline $4=action_time
+	# rewrite file (small N)
+	{ awk -F: -v k="$1" '$1!=k {print}' "$RECOVER_STATE" 2>/dev/null; echo "$1:$2:$3:$4"; } >"$RECOVER_STATE.n" && mv "$RECOVER_STATE.n" "$RECOVER_STATE"
+}
+state_del() {
+	{ awk -F: -v k="$1" '$1!=k {print}' "$RECOVER_STATE" 2>/dev/null; } >"$RECOVER_STATE.n" && mv "$RECOVER_STATE.n" "$RECOVER_STATE"
+}
+
+# Parse robocfg show to build port list dynamically
+build_ports() {
+	local vlan_num="$1"
+	local robocfg_out
+	
+	robocfg_out=$(robocfg show 2>/dev/null)
+	
+	# Use single awk pass to:
+	# 1. Extract UP ports 0-4
+	# 2. Extract VLAN port list
+	# 3. Map port to interface
+	echo "$robocfg_out" | awk -v vlan="$vlan_num" '
+	/^Port [0-4]:/ && !/DOWN/ {
+		port = substr($2, 1, length($2)-1)
+		up_ports[port] = 1
+	}
+	$0 ~ "^   " vlan ":" {
+		# Extract port list from VLAN line
+		line = $0
+		sub(/^[^:]*: *vlan[0-9]*: */, "", line)
+		sub(/ [0-9]*t.*/, "", line)
+		gsub(/[ut]/, "", line)
+		ports = line
+	}
+	END {
+		# Map UP ports to interfaces
+		n = split(ports, p)
+		for (i = 1; i <= n; i++) {
+			port = p[i]
+			if (port ~ /^[0-4]$/ && port in up_ports) {
+				if (port == 0) iface = "eth0"
+				else if (port ~ /[1-3]/) iface = "eth1"
+				else if (port == 4) iface = "eth2"
+				printf "%s:%s ", port, iface
+			}
+		}
+		print ""
+	}'
+}
+
+# Get cached port list or rebuild if stale (cache TTL configurable via CACHE_TIMEOUT)
+get_ports_cached() {
+	local if_type="$1"
+	local cache_file="$STATE_DIR/ports.$if_type.cache"
+	local now=$N cache_time
+	
+	if [ -f "$cache_file" ]; then
+		cache_time=$(get_mtime "$cache_file")
+		if [ $((now - cache_time)) -lt "$CACHE_TIMEOUT" ]; then
+			cat "$cache_file"
+			return 0
+		fi
+	fi
+	
+	# Cache expired or doesn't exist; rebuild
+	local ports
+	case "$if_type" in
+		w) ports=$(build_ports 2) ;;
+		a) 
+			local lan=$(build_ports 1)
+			local wan=$(build_ports 2)
+			ports="$lan $wan"
+			;;
+		l|*) ports=$(build_ports 1) ;;
+	esac
+	echo "$ports" > "$cache_file"
+	echo "$ports"
+}
+
+# Determine which ports to monitor (use cache for speed in monitor mode)
+PORTS=$(get_ports_cached "$IF_TYPE")
+
+# Build new cache while checking
+SUM=0
+: >"$COUNTERS.n"
+FAULTY=""
+MAX_DELTA=0
+
+# Read old counters into memory (single pass instead of awk per port)
+OLD_COUNTERS=$(cat "$COUNTERS" 2>/dev/null)
+
+for PORTMAP in $PORTS; do
+	PORT=${PORTMAP%:*}
+	IFACE=${PORTMAP#*:}
+	[ -d "/sys/class/net/$IFACE" ] || continue
+	
+	# Read error counters
+	read rx_err <"/sys/class/net/$IFACE/statistics/rx_errors" 2>/dev/null || rx_err=0
+	read tx_err <"/sys/class/net/$IFACE/statistics/tx_errors" 2>/dev/null || tx_err=0
+	read rx_drop <"/sys/class/net/$IFACE/statistics/rx_dropped" 2>/dev/null || rx_drop=0
+	read tx_drop <"/sys/class/net/$IFACE/statistics/tx_dropped" 2>/dev/null || tx_drop=0
+	read rx_over <"/sys/class/net/$IFACE/statistics/rx_over_errors" 2>/dev/null || rx_over=0
+	read frame <"/sys/class/net/$IFACE/statistics/rx_frame_errors" 2>/dev/null || frame=0
+	read carrier <"/sys/class/net/$IFACE/statistics/tx_carrier_errors" 2>/dev/null || carrier=0
+	read coll <"/sys/class/net/$IFACE/statistics/collisions" 2>/dev/null || coll=0
+	X=$((rx_err + tx_err + rx_drop + tx_drop + rx_over + frame + carrier + coll))
+	
+	SUM=$((SUM + X))
+	echo "port_$PORT:$X" >>"$COUNTERS.n"
+
+	# Get old value from memory instead of awk from file
+	O=$(printf '%s\n' "$OLD_COUNTERS" | awk -F: -v p="port_$PORT" '$1==p {print $2; exit}')
+	[ -z "$O" ] && O=0
+	
+	D=$((X - O))
+	# Track the port with highest error delta
+	[ "$D" -gt "$MAX_DELTA" ] && { MAX_DELTA=$D; FAULTY=$PORT; }
+done
+
+# Check if any port exceeded threshold
+if [ -z "$FAULTY" ] || [ "$MAX_DELTA" -le "$R" ]; then
+	mv "$COUNTERS.n" "$COUNTERS"
+	printf '%s\n' "$SUM" > "$ERROR_SUM"
+	exit 0
+fi
+
+# Flood detected on port
+case "$MODE" in
+	monitor)
+		log_warn "FLOOD port $FAULTY (delta=$MAX_DELTA thr=$R)";
+		;;
+	disable)
+		log_err "FLOOD port $FAULTY (disable)";
+		robocfg port "$FAULTY" state disable >/dev/null 2>&1
+		;;
+	recover)
+		set -- $(state_get "port_$FAULTY")
+		idx="$1"
+		if [ -z "$idx" ]; then
+			idx=1
+			step=$(echo "$STEPS" | awk -v n="$idx" '{print $n}')
+			robocfg port "$FAULTY" speed "$step" >/dev/null 2>&1
+			state_set "port_$FAULTY" "$idx" "$MAX_DELTA" "$N"
+			log_warn "RECOVER START port $FAULTY -> $step"
+		else
+			action_time=$(state_get "port_$FAULTY" | awk '{print $3}')
+			elapsed=$((N - action_time))
+			if [ "$elapsed" -ge "$HOLD_TIME" ]; then
+				R_eval=$((BASE_RATE * elapsed / 60))
+				[ "$R_eval" -lt 1 ] && R_eval=1
+				if [ "$MAX_DELTA" -le "$R_eval" ]; then
+					log_warn "RECOVER OK port $FAULTY"
+					state_del "port_$FAULTY"
+				else
+					idx=$((idx+1))
+					step=$(echo "$STEPS" | awk -v n="$idx" '{print $n}')
+					if [ -z "$step" ]; then
+						log_err "RECOVER FAIL port $FAULTY (disable)"
+						robocfg port "$FAULTY" state disable >/dev/null 2>&1
+						state_del "port_$FAULTY"
+					else
+						robocfg port "$FAULTY" speed "$step" >/dev/null 2>&1
+						state_set "port_$FAULTY" "$idx" "$MAX_DELTA" "$N"
+						log_warn "RECOVER STEP port $FAULTY -> $step"
+					fi
+				fi
+			fi
+		fi
+		;;
+	*)
+		log_warn "Unknown mode '$MODE' (using monitor)";
+		log_warn "FLOOD port $FAULTY (delta=$MAX_DELTA thr=$R)";
+		;;
+esac
+
+mv "$COUNTERS.n" "$COUNTERS"
+printf '%s\n' "$SUM" > "$ERROR_SUM"

--- a/release/src-rt-6.x.4708/router/rc/services.c
+++ b/release/src-rt-6.x.4708/router/rc/services.c
@@ -97,6 +97,104 @@ static pid_t pid_ntpd = -1;
 static pid_t pid_phy_tempsense = -1;
 #endif
 
+/*
+ * Port Health
+ * - Managed via cron (cru)
+ * - Script installed at: /usr/sbin/porthealth.sh
+ * - Settings in nvram: porthealth_cfg
+ *   Format: enable=1,mode=monitor,max=50,hold=180,cache=60,if=l
+ */
+
+static void stop_porthealth(void)
+{
+	/* remove cron job if present */
+	eval("cru", "d", "porthealth");
+}
+
+static void start_porthealth(void)
+{
+	char cfgbuf[256];
+	char sched[256];
+	char mode[16];
+	char ift[4];
+	char *p;
+	char *tok;
+	char *eq;
+	char *k;
+	char *v;
+	int enable = 0;
+	int max_i = 50;
+	int hold_i = 180;
+	int cache_i = 60;
+	const char *cfg;
+
+	stop_porthealth();
+
+	cfg = nvram_safe_get("porthealth_cfg");
+	if ((cfg == NULL) || (cfg[0] == '\0'))
+		return;
+
+	strlcpy(cfgbuf, cfg, sizeof(cfgbuf));
+	strlcpy(mode, "monitor", sizeof(mode));
+	strlcpy(ift, "l", sizeof(ift));
+
+	for (p = cfgbuf; (tok = strsep(&p, ",")) != NULL; ) {
+		/* trim leading spaces */
+		while (*tok == ' ' || *tok == '\t') tok++;
+		if (*tok == '\0') continue;
+		eq = strchr(tok, '=');
+		if (eq == NULL) continue;
+		*eq++ = '\0';
+		k = tok;
+		v = eq;
+		/* trim trailing spaces in key */
+		{
+			char *end = k + strlen(k);
+			while (end > k && (end[-1] == ' ' || end[-1] == '\t')) *--end = '\0';
+		}
+		while (*v == ' ' || *v == '\t') v++;
+
+		if (strcmp(k, "enable") == 0) {
+			enable = atoi(v);
+		}
+		else if (strcmp(k, "mode") == 0) {
+			strlcpy(mode, v, sizeof(mode));
+		}
+		else if (strcmp(k, "if") == 0) {
+			strlcpy(ift, v, sizeof(ift));
+		}
+		else if (strcmp(k, "max") == 0) {
+			max_i = atoi(v);
+		}
+		else if (strcmp(k, "hold") == 0) {
+			hold_i = atoi(v);
+		}
+		else if (strcmp(k, "cache") == 0) {
+			cache_i = atoi(v);
+		}
+	}
+
+	if (enable != 1)
+		return;
+
+	if ((strcmp(mode, "monitor") != 0) && (strcmp(mode, "recover") != 0) && (strcmp(mode, "disable") != 0))
+		strlcpy(mode, "monitor", sizeof(mode));
+
+	if ((strcmp(ift, "l") != 0) && (strcmp(ift, "w") != 0) && (strcmp(ift, "a") != 0))
+		strlcpy(ift, "l", sizeof(ift));
+
+	if (max_i < 1) max_i = 1;
+	if (max_i > 100000) max_i = 100000;
+	if (hold_i < 1) hold_i = 1;
+	if (hold_i > 86400) hold_i = 86400;
+	if (cache_i < 0) cache_i = 0;
+	if (cache_i > 86400) cache_i = 86400;
+
+	/* Run every minute; script is designed to be fast in monitor mode */
+	snprintf(sched, sizeof(sched), "* * * * * /usr/sbin/porthealth.sh %s max=%d hold=%d cache=%d if=%s", mode, max_i, hold_i, cache_i, ift);
+	eval("cru", "a", "porthealth", sched);
+}
+
 void add_rstats_defaults(void)
 {
 #ifdef TCONFIG_BCMARM
@@ -2317,6 +2415,7 @@ void start_services(void)
 	start_mysql(0);
 #endif
 	start_cron();
+	start_porthealth(); /* cron-based */
 #ifdef TCONFIG_PPTPD
 	start_pptpd(0);
 #endif
@@ -2404,6 +2503,7 @@ void stop_services(void)
 	stop_pptpd();
 #endif
 	stop_sched();
+	stop_porthealth();
 	stop_cron();
 #ifdef TCONFIG_NGINX
 	stop_mysql();
@@ -3081,6 +3181,12 @@ TOP:
 	if (strcmp(service, "tomatoanon") == 0) {
 		if (act_stop) stop_tomatoanon();
 		if (act_start) start_tomatoanon();
+		goto CLEAR;
+	}
+
+	if (strcmp(service, "porthealth") == 0) {
+		if (act_stop) stop_porthealth();
+		if (act_start) start_porthealth();
 		goto CLEAR;
 	}
 

--- a/release/src-rt-6.x.4708/router/www/advanced-misc.asp
+++ b/release/src-rt-6.x.4708/router/www/advanced-misc.asp
@@ -18,18 +18,62 @@
 
 <script>
 
-//	<% nvram("t_features,wait_time,wan_speed,jumbo_frame_enable,jumbo_frame_size,ctf_disable,bcmnat_disable"); %>
+//	<% nvram("t_features,wait_time,wan_speed,jumbo_frame_enable,jumbo_frame_size,ctf_disable,bcmnat_disable,porthealth_cfg"); %>
 
 et1000 = features('1000et');
 
+function _phTrim(s) {
+	return (s || '').replace(/^\s+|\s+$/g, '');
+}
+
+function _phCfg() {
+	var cfg = nvram.porthealth_cfg || '';
+	var o = { enable: 0, mode: 'monitor', max: 50, hold: 180, cache: 60, ift: 'l' };
+	var parts, i, kv, k, v;
+
+	cfg = _phTrim(cfg);
+	if (cfg.length == 0) return o;
+
+	parts = cfg.split(',');
+	for (i = 0; i < parts.length; ++i) {
+		kv = parts[i].split('=');
+		if (kv.length < 2) continue;
+		k = _phTrim(kv[0]);
+		v = _phTrim(kv.slice(1).join('='));
+		if (k == 'enable') o.enable = (v == '1') ? 1 : 0;
+		else if (k == 'mode') o.mode = v;
+		else if (k == 'max') o.max = v * 1;
+		else if (k == 'hold') o.hold = v * 1;
+		else if (k == 'cache') o.cache = v * 1;
+		else if (k == 'if') o.ift = v;
+	}
+
+	if ((o.mode != 'monitor') && (o.mode != 'recover') && (o.mode != 'disable')) o.mode = 'monitor';
+	if ((o.ift != 'l') && (o.ift != 'w') && (o.ift != 'a')) o.ift = 'l';
+	o.max = fixInt(o.max, 1, 100000, 50);
+	o.hold = fixInt(o.hold, 1, 86400, 180);
+	o.cache = fixInt(o.cache, 0, 86400, 60);
+
+	return o;
+}
+
 function verifyFields(focused, quiet) {
 	E('_jumbo_frame_size').disabled = !E('_f_jumbo_frame_enable').checked;
+
+	if (!v_range(E('_f_porthealth_max'), quiet, 1, 100000)) return 0;
+	if (!v_range(E('_f_porthealth_hold'), quiet, 1, 86400)) return 0;
+	if (!v_range(E('_f_porthealth_cache'), quiet, 0, 86400)) return 0;
 
 	return 1;
 }
 
 function save() {
 	var fom = E('t_fom');
+	var ph;
+
+	if (!verifyFields(null, 0))
+		return;
+
 	fom.jumbo_frame_enable.value = E('_f_jumbo_frame_enable').checked ? 1 : 0;
 /* CTF-BEGIN */
 	fom.ctf_disable.value = E('_f_ctf_disable').checked ? 0 : 1;
@@ -37,6 +81,22 @@ function save() {
 /* BCMNAT-BEGIN */
 	fom.bcmnat_disable.value = E('_f_bcmnat_disable').checked ? 0 : 1;
 /* BCMNAT-END */
+
+	/* Port Health */
+	ph = {
+		enable: E('_f_porthealth_enable').checked ? 1 : 0,
+		mode: E('_f_porthealth_mode').value,
+		max: E('_f_porthealth_max').value,
+		hold: E('_f_porthealth_hold').value,
+		cache: E('_f_porthealth_cache').value,
+		ift: E('_f_porthealth_if').value
+	};
+	fom.porthealth_cfg.value = 'enable=' + (ph.enable ? 1 : 0) +
+		',mode=' + ph.mode +
+		',max=' + ph.max +
+		',hold=' + ph.hold +
+		',cache=' + ph.cache +
+		',if=' + ph.ift;
 
 	if ((fom.wan_speed.value != nvram.wan_speed) ||
 /* CTF-BEGIN */
@@ -77,6 +137,7 @@ function save() {
 
 <input type="hidden" name="_nextpage" value="advanced-misc.asp">
 <input type="hidden" name="_reboot" value="0">
+<input type="hidden" name="_service" value="porthealth-restart">
 <input type="hidden" name="jumbo_frame_enable">
 <!-- CTF-BEGIN -->
 <input type="hidden" name="ctf_disable">
@@ -85,11 +146,14 @@ function save() {
 <input type="hidden" name="bcmnat_disable">
 <!-- BCMNAT-END -->
 
+<input type="hidden" name="porthealth_cfg">
+
 <!-- / / / -->
 
 <div class="section-title">Miscellaneous</div>
 <div class="section">
 	<script>
+		ph = _phCfg();
 		a = [];
 		for (i = 3; i <= 20; ++i) a.push([i, i + ' seconds']);
 		createFieldTable('', [
@@ -105,7 +169,23 @@ function save() {
 /* BCMNAT-END */
 			{ title: 'Enable Jumbo Frames *', name: 'f_jumbo_frame_enable', type: 'checkbox', value: nvram.jumbo_frame_enable != '0', hidden: !et1000 },
 			{ title: 'Jumbo Frame Size *', name: 'jumbo_frame_size', type: 'text', maxlen: 4, size: 6, value: fixInt(nvram.jumbo_frame_size, 1, 9720, 2000),
-				suffix: ' <small>Bytes (range: 1 - 9720; default: 2000)<\/small>', hidden: !et1000 }
+				suffix: ' <small>Bytes (range: 1 - 9720; default: 2000)<\/small>', hidden: !et1000 },
+			null,
+			{ title: 'Port Health', text: '<small>Monitors switch ports 0-4; VLAN role comes from robocfg show.<\/small>' },
+			{ title: 'Enable', name: 'f_porthealth_enable', type: 'checkbox', value: ph.enable == 1 },
+			{ title: 'Mode', name: 'f_porthealth_mode', type: 'select', value: ph.mode, options: [
+				['monitor','Monitor (log only)'],
+				['recover','Recover (step down speed)'],
+				['disable','Disable port']
+			] },
+			{ title: 'Ports', name: 'f_porthealth_if', type: 'select', value: ph.ift, options: [
+				['l','LAN only'],
+				['w','WAN only'],
+				['a','LAN + WAN']
+			] },
+			{ title: 'Max Errors / Minute', name: 'f_porthealth_max', type: 'text', value: ph.max, maxlen: 6, size: 8 },
+			{ title: 'Hold Time (seconds)', name: 'f_porthealth_hold', type: 'text', value: ph.hold, maxlen: 6, size: 8, suffix: ' <small>(recover mode only)<\\/small>' },
+			{ title: 'Cache TTL (seconds)', name: 'f_porthealth_cache', type: 'text', value: ph.cache, maxlen: 6, size: 8, suffix: ' <small>(0 disables caching)<\\/small>' }
 		]);
 	</script>
 


### PR DESCRIPTION
Adds a new function to monitor errors on the Ethernet ports. It prevents the router from crashing when having to deal with numerous bad frames, whether related to port speed mismatch or cabling issues. It uses a new, single, porthealth_cfg nvram variable,

<img width="974" height="296" alt="image" src="https://github.com/user-attachments/assets/79db2a01-e497-4e2c-8a4e-6f0904780142" />

It can monitor (only), try to recover or disable when threshold is breached.
When enabled it runs every minute, however its execution time is around 0.02s-0.03s.
The output is not human friendly but can be verified under /tmp/porthealth/

