### PR TITLE
Update defaults.c disable telnet enable at startup

### DIFF
--- a/release/src-rt-6.x.4708/router/shared/defaults.c
+++ b/release/src-rt-6.x.4708/router/shared/defaults.c
@@ -1127,7 +1127,7 @@ struct nvram_tuple router_defaults[] = {
 	{ "ttb_url",			"http://ttb.mooo.com http://ttb.ath.cx http://ttb.ddnsfree.com", 0 },	/* Tomato Themes Base - default URL */
 #endif
 	{ "web_svg",			"1"				, 0 },
-	{ "telnetd_eas",		"1"				, 0 },
+	{ "telnetd_eas",		"0"				, 0 },
 	{ "telnetd_port",		"23"				, 0 },
 	{ "sshd_eas",			"1"				, 0 },	/* enable sshd by default */
 	{ "sshd_pass",			"1"				, 0 },


### PR DESCRIPTION
[ $1 -ge 20 ] && telnetd -p (yourporthere) -l /bin/sh

already exists to bypass password...

Don't this open up telnet on port (yourporthere) and drop you into a root shell where you can already get the username and password if you are locked out using nvram get and the variables?