### PR TITLE
tomato.js - allows for placeholder to work on password fields

### DIFF
--- a/release/src-rt-6.x.4708/router/www/tomato.js
+++ b/release/src-rt-6.x.4708/router/www/tomato.js
@@ -2889,6 +2889,8 @@ function peekaboo(id, show) {
 		var name = e.name;
 		o.type = show ? 'text' : 'password';
 		o.value = e.value;
+		/* preserve placeholder when swapping input types */
+		try { o.placeholder = e.placeholder; } catch (ex) {}
 		o.size = e.size;
 		o.maxLength = e.maxLength;
 		o.autocomplete = e.autocomplete;


### PR DESCRIPTION
Preserve placeholder attribute when swapping input types.