### PR TITLE
GUI: fix id mismatch in generation of vpn client config

### DIFF
--- a/release/src-rt-6.x.4708/router/www/vpn-server.asp
+++ b/release/src-rt-6.x.4708/router/www/vpn-server.asp
@@ -535,10 +535,10 @@ function downloadClientConfig(num) {
 		}
 	}
 
-	elem.display(E('server'+num+'_gen_progress_div'), true);
+	elem.display(E('vpns'+num+'_gen_progress_div'), true);
 	keyGenRequest = new XmlHttp();
 	keyGenRequest.onCompleted = function(text, xml) {
-		elem.display(E('server'+num+'_gen_progress_div'), false);
+		elem.display(E('vpns'+num+'_gen_progress_div'), false);
 		keyGenRequest = null;
 
 		var dlFileFakeLink = document.createElement('a');


### PR DESCRIPTION
Fix for the generation of VPN client config failing because of mismatching IDs since renaming the nvram variables. The HTML contains a field called `vpns1_gen_progress_div` but the function `downloadClientConfig` tries to find the selector `server1_gen_progress_div` instead. The element cannot be found which is causing a JavaScript exception.