### PR TITLE
rc: Add trx, chk and bin firmware images integrity validation

### DIFF
--- a/release/src-rt-6.x.4708/router/rc/Makefile
+++ b/release/src-rt-6.x.4708/router/rc/Makefile
@@ -28,7 +28,7 @@ OBJS = rc.o init.o interface.o network.o wan.o services.o dhcp.o \
        firewall.o ppp.o telssh.o wnas.o listen.o redial.o \
        led.o qos.o forward.o misc.o mtd.o buttons.o restrict.o \
        gpio.o sched.o bwlimit.o arpbind.o tomatoanon.o mwan.o pbr.o \
-       dnsmasq.o format.o
+       dnsmasq.o format.o trx_check.o
 
 ifeq ($(or $(TCONFIG_BCMARM),$(TCONFIG_BLINK)),y)
  OBJS += blink.o blink_br.o
@@ -177,6 +177,7 @@ endif
 	@cd $(INSTALLDIR)/sbin && ln -sf rc ppp_event
 
 	@cd $(INSTALLDIR)/sbin && ln -sf rc ntpd_synced
+	@cd $(INSTALLDIR)/sbin && ln -sf rc trx_check
 
 ifeq ($(TCONFIG_BCMARM),y)
 	@cd $(INSTALLDIR)/sbin && ln -sf rc mtd-write2

--- a/release/src-rt-6.x.4708/router/rc/rc.c
+++ b/release/src-rt-6.x.4708/router/rc/rc.c
@@ -18,6 +18,8 @@
  #include <setjmp.h>
 #endif
 
+extern int trx_check_main(int argc, char **argv);
+
 /* needed by logmsg() */
 #define LOGMSG_DISABLE	DISABLE_SYSLOG_OSM
 #define LOGMSG_NVDEBUG	"rc_debug"
@@ -247,7 +249,7 @@ void run_del_firewall_script(const char *infile, char *outfile)
  * @param	out	pointer to a buffer where the function writes the normalized result
  * @param	outlen	size of the out buffer
  * @return	1 if str is a valid IPv4 or IPv4/mask; out receives a normalized string in the form A.B.C.D/n with n coerced into semantics, defaulting to /32 when absent or invalid
- *		2 if str is a valid IPv4 range “A.B.C.D-E.F.G.H” with no internal whitespace and both addresses in the same /24; out receives the unchanged “A.B.C.D-E.F.G.H”
+ *		2 if str is a valid IPv4 range ï¿½A.B.C.D-E.F.G.Hï¿½ with no internal whitespace and both addresses in the same /24; out receives the unchanged ï¿½A.B.C.D-E.F.G.Hï¿½
  * 		0 if str is something else (FQDN?)
  */
 static int check_string(const char *str, char *out, size_t outlen)
@@ -894,6 +896,7 @@ static const applets_t applets[] = {
 #ifdef TCONFIG_ROAM
 	{ "roamast",			roam_assistant_main		},
 #endif
+    { "trx_check", trx_check_main },
 	{NULL, NULL}
 };
 

--- a/release/src-rt-6.x.4708/router/rc/trx_check.c
+++ b/release/src-rt-6.x.4708/router/rc/trx_check.c
@@ -1,0 +1,147 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stddef.h>
+
+#define TRX_MAGIC           0x30524448  /* "HDR0" */
+#define NETGEAR_MAGIC       0x5E24232A  /* Netgear CHK */
+#define TRX_MAX_LEN         0x4000000   /* 64MB */
+
+static uint32_t crc32_tab[256];
+static int verbose = 0;
+
+static void init_crc32(void) {
+    uint32_t i, j, c;
+    for (i = 0; i < 256; i++) {
+        for (c = i, j = 8; j > 0; j--)
+            c = (c & 1) ? (0xEDB88320L ^ (c >> 1)) : (c >> 1);
+        crc32_tab[i] = c;
+    }
+}
+
+static uint32_t crc32_calc(uint32_t crc, const uint8_t *buf, size_t len) {
+    while (len--) crc = crc32_tab[(crc ^ *buf++) & 0xFF] ^ (crc >> 8);
+    return crc;
+}
+
+struct trx_header {
+    uint32_t magic, len, crc32, flag_version, offsets[3];
+};
+
+static int perform_check(const char *fn) {
+    int fd, res = 1;
+    struct stat st;
+    uint8_t *buf;
+
+    if (!fn) return 1;
+    fd = open(fn, O_RDONLY);
+    if (fd < 0) {
+        fprintf(stderr, "ERROR: Cannot open %s\n", fn);
+        return 4;
+    }
+    
+    if (fstat(fd, &st) < 0 || st.st_size < 32) {
+        close(fd);
+        return 3;
+    }
+
+    buf = mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    if (buf == MAP_FAILED) {
+        close(fd);
+        return 4;
+    }
+
+    if (verbose) {
+        printf("\nAnalyzing File: %s\n", fn);
+        printf("Size: %zu bytes\n", (size_t)st.st_size);
+    }
+
+    uint32_t magic = *(uint32_t *)buf;
+
+    /* 1. TRX Check */
+    if (magic == TRX_MAGIC) {
+        struct trx_header *h = (struct trx_header *)buf;
+        if (verbose) {
+            printf("Type: TRX (Broadcom)\n");
+            printf("  Magic: 0x%08x (HDR0)\n", h->magic);
+            printf("  Header Length: %u\n", h->len);
+        }
+
+        if (h->len > st.st_size || h->len > TRX_MAX_LEN) {
+            if (verbose) printf("  ERROR: Length mismatch or exceeds 64MB limit\n");
+            res = 3;
+        } else {
+            init_crc32();
+            uint32_t calc = crc32_calc(0xFFFFFFFF, (uint8_t *)&h->flag_version, h->len - 12);
+            if (verbose) {
+                printf("  Expected CRC:   0x%08x\n", h->crc32);
+                printf("  Calculated CRC: 0x%08x\n", calc);
+            }
+            res = (calc == h->crc32) ? 0 : 2;
+        }
+    } 
+    /* 2. CHK Check */
+    else if (magic == NETGEAR_MAGIC) {
+        if (verbose) printf("Type: Netgear CHK (Verified by Magic)\n");
+        res = 0; 
+    } 
+    /* 3. BIN/Generic Check */
+    else {
+        int found = 0;
+        for (int i = 0; i < 512 && i < st.st_size - 32; i++) {
+            if (memcmp(buf + i, "U2ND", 4) == 0 || memcmp(buf + i, "HDR0", 4) == 0) {
+                if (verbose) printf("Type: BIN (Linksys/ASUS) - Identifier found at offset %d\n", i);
+                found = 1;
+                res = 0;
+                break;
+            }
+        }
+        if (!found && verbose) printf("Type: Unknown (Magic: 0x%08x)\n", magic);
+    }
+
+    /* Final Output */
+    if (!verbose) {
+        printf("%s: %s\n", fn, (res == 0) ? "VALID" : "INVALID");
+    } else {
+        printf("Final Result: %s\n------------------------------\n", (res == 0) ? "✓ VALID" : "✗ INVALID");
+    }
+
+    munmap(buf, st.st_size);
+    close(fd);
+    return res;
+}
+
+int trx_check_main(int argc, char *argv[]) {
+    int ch, i;
+    int first_file_idx = -1;
+    verbose = 0;
+    optind = 0;
+
+    while ((ch = getopt(argc, argv, "vhi:")) != -1) {
+        switch (ch) {
+            case 'v': verbose = 1; break;
+            case 'i': first_file_idx = optind - 1; break;
+            case 'h': 
+            default:
+                printf("TRX/CHK/BIN Firmware Checker\n");
+                printf("Usage: trx_check [-v] -i <file1> [file2...]\n");
+                return 0;
+        }
+    }
+
+    if (first_file_idx != -1) {
+        for (i = first_file_idx; i < argc; i++) {
+            if (strcmp(argv[i], "-i") == 0) continue;
+            perform_check(argv[i]);
+        }
+    } else {
+        printf("Error: Use -i to specify firmware files.\n");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Hi Pedro! 

This is AI generated and just before making this PR I noticed the AI messed things up a little bit. I will post this anyway since it is late and worked too much on this.

This validate image files before flashing them.

What work:
  - It seem to correctly check images files in trx, chk and bin format.
  - It can output a simple 1 line valid output 
  - Or with the -v option it can give details. 
  - It can take many files as input and check then all at once.
  - option -h to get help. 
  - option -v must come before -i

What doesn't work: 
  - If the image is invalid there's no output and no error code. echo $? Return 0 which is NOT ok.
  - option --help have probably been removed by the Artificial Dumb Dumb.

I can try to fix this tomorrow or maybe it is an easy fix??? Or maybe this is a waste of time? 

```bash
root@AC68U-Relais:/tmp/home/root/usbr/firmwares# trx_check -h
TRX/CHK/BIN Firmware Checker
Usage: trx_check [-v] -i <file1> [file2...]

# broken image make no output and return a 0 error code. NOT good!
root@AC68U-Relais:/tmp/home/root/usbr/firmwares# trx_check -i test.trx
root@AC68U-Relais:/tmp/home/root/usbr/firmwares# echo $?
0
root@AC68U-Relais:/tmp/home/root/usbr/firmwares# trx_check -v -i test.trx

root@AC68U-Relais:/tmp/home/root/usbr/firmwares# trx_check -v -i vpn.trx

Analyzing File: vpn.trx
Size: 15577088 bytes
Type: TRX (Broadcom)
  Magic: 0x30524448 (HDR0)
  Header Length: 15577088
  Expected CRC:   0x423fd288
  Calculated CRC: 0x423fd288
Final Result: ✓ VALID
------------------------------

root@AC68U-Relais:/tmp/home/root/usbr/firmwares# trx_check -i vpn.trx
vpn.trx: VALID

root@AC68U-Relais:/tmp/home/root/usbr/firmwares# trx_check -i vpn.trx aio.trx
vpn.trx: VALID
aio.trx: VALID

root@AC68U-Relais:/tmp/home/root/usbr/firmwares# trx_check -v -i vpn.trx aio.trx

Analyzing File: vpn.trx
Size: 15577088 bytes
Type: TRX (Broadcom)
  Magic: 0x30524448 (HDR0)
  Header Length: 15577088
  Expected CRC:   0x423fd288
  Calculated CRC: 0x423fd288
Final Result: ✓ VALID
------------------------------

Analyzing File: aio.trx
Size: 31719424 bytes
Type: TRX (Broadcom)
  Magic: 0x30524448 (HDR0)
  Header Length: 31719424
  Expected CRC:   0x1f37b957
  Calculated CRC: 0x1f37b957
Final Result: ✓ VALID
------------------------------
```

What do you guys think? I don't know if you all saw my other iteration, but the first one by Copilot using Claude was about 400 lines. This one by Gemini is ~150 lines.

IMO this is worth it. You guys tell me.

On this, good night for me and probably good morning to you on the other side of the Atlantic 🙂