### PR TITLE
GUI:  Scan SSID/BSSID improvement

### DIFF
--- a/release/src-rt-6.x.4708/router/www/advanced-wlanvifs.asp
+++ b/release/src-rt-6.x.4708/router/www/advanced-wlanvifs.asp
@@ -33,7 +33,7 @@ var lastjiffiestotal = 0, lastjiffiesidle = 0, lastjiffiesusage = 100;
 
 <script>
 
-//	<% nvram("wl_auth,wl_auth_mode,wl_ap_isolate,wl_bss_enabled,wl_channel,wl_closed,wl_corerev,wl_crypto,wl_hwaddr,wl_ifname,wl_key,wl_key1,wl_key2,wl_key3,wl_key4,wl_lazywds,wl_mode,wl_nband,wl_nbw_cap,wl_nctrlsb,wl_net_mode,wl_passphrase,wl_phytype,wl_radio,wl_radius_ipaddr,wl_radius_key,wl_radius_port,wl_security_mode,wl_ssid,wl_vifs,wl_wds,wl_wds_enable,wl_wep_bit,wl_wpa_gtk_rekey,wl_wpa_psk,wl_bss_maxassoc,wl_wme,lan_ifname,lan_ifnames,t_features,wl_macmode,wl_maclist");%>
+//	<% nvram("wl_auth,wl_auth_mode,wl_ap_isolate,wl_bss_enabled,wl_channel,wl_clap_hwaddr,wl_closed,wl_corerev,wl_crypto,wl_hwaddr,wl_ifname,wl_key,wl_key1,wl_key2,wl_key3,wl_key4,wl_lazywds,wl_mode,wl_nband,wl_nbw_cap,wl_nctrlsb,wl_net_mode,wl_passphrase,wl_phytype,wl_radio,wl_radius_ipaddr,wl_radius_key,wl_radius_port,wl_security_mode,wl_ssid,wl_vifs,wl_wds,wl_wds_enable,wl_wep_bit,wl_wpa_gtk_rekey,wl_wpa_psk,wl_bss_maxassoc,wl_wme,lan_ifname,lan_ifnames,wan_ifname,wan2_ifname,wan3_ifname,wan4_ifname,t_features,wl_macmode,wl_maclist");%>
 
 var cprefix = 'advanced_wlanvifs';
 var vifs_possible = [];
@@ -50,7 +50,110 @@ var wmo = {'ap':'Access Point','apwds':'Access Point + WDS','sta':'Wireless Clie
 	   };
 var macmode = {'disabled':'Disabled','deny':'Block','allow':'Permit'};
 
-var tabs = [['overview','Overview']];
+var tabs = [['overview','Overview<br>&#8203']];
+
+function getWanIndex(u) {
+	var ifname = nvram['wl'+u+'_ifname'] || ('wl'+u);
+	if (nvram.wan_ifname && nvram.wan_ifname.indexOf(ifname) !== -1) return 0;
+	if (nvram.wan2_ifname && nvram.wan2_ifname.indexOf(ifname) !== -1) return 1;
+	/* REMOVE-BEGIN */
+	if (hasMultiWan) {
+	/* REMOVE-END */
+	if (nvram.wan3_ifname && nvram.wan3_ifname.indexOf(ifname) !== -1) return 2;
+	if (nvram.wan4_ifname && nvram.wan4_ifname.indexOf(ifname) !== -1) return 3;
+	/* REMOVE-BEGIN */
+	}
+	/* REMOVE-END */
+	return 4;
+}
+
+function displayIfnameWithBand(u) {
+	var uidx = wl_ifidxx(u);
+	if (uidx >= 0) return wl_display_ifname(uidx);
+	var base = 'wl'+u;
+	var unit = (u.toString().indexOf('.') > -1) ? u.toString().split('.')[0] : u.toString();
+	var pidx = wl_uidx(unit);
+	var bandSuffix = '';
+	if (pidx >= 0) {
+		if (wl_bands[pidx].length == 1)
+			bandSuffix = (wl_bands[pidx][0] == '1') ? ' / 5 GHz' : ' / 2.4 GHz';
+		else
+			bandSuffix = (nvram['wl'+u+'_nband'] == 1) ? ' / 5 GHz' : ' / 2.4 GHz';
+	}
+	return base + bandSuffix;
+}
+
+function stripIfname(list, ifname) {
+	if (!list) return '';
+	var parts = list.split(/\s+/);
+	var kept = [];
+	for (var i = 0; i < parts.length; ++i) {
+		if (parts[i] && parts[i] != ifname) kept.push(parts[i]);
+	}
+	return kept.join(' ');
+}
+
+function setBridgeOptions(select, mode, u) {
+	if (!select) return;
+	var isSta = (mode === 'sta');
+	var target = isSta ? 'wan' : 'lan';
+	if (select.getAttribute('data-bridge-mode') === target) return;
+
+	var staOptions = [[0,'WAN0'],[1,'WAN1']];
+	/* REMOVE-BEGIN */
+	if (hasMultiWan) {
+	/* REMOVE-END */
+		staOptions.push([2,'WAN2'],[3,'WAN3']);
+	/* REMOVE-BEGIN */
+	}
+	/* REMOVE-END */
+	staOptions.push([4,'none']);
+	var options = isSta ?
+		staOptions :
+		[[0,'LAN0 (br0)'],[1,'LAN1 (br1)'],[2,'LAN2 (br2)'],[3,'LAN3 (br3)'],[4,'none']];
+
+	var currentValue = select.value;
+	while (select.options.length) select.remove(0);
+	for (var i = 0; i < options.length; ++i)
+		select.options.add(new Option(options[i][1], options[i][0]));
+	select.setAttribute('data-bridge-mode', target);
+
+	if (isSta)
+		select.value = (currentValue === '' || currentValue === '4' || typeof currentValue === 'undefined') ? getWanIndex(u) : currentValue;
+	else
+		select.value = (currentValue === '' || typeof currentValue === 'undefined') ? '4' : currentValue;
+
+	if (isSta) {
+		if (!nvram.wan_ifname || nvram.wan_ifname.length < 1)
+			select.options[0].disabled = 1;
+		if (!nvram.wan2_ifname || nvram.wan2_ifname.length < 1)
+			select.options[1].disabled = 1;
+	/* REMOVE-BEGIN */
+	if (hasMultiWan) {
+	/* REMOVE-END */
+		if (!nvram.wan3_ifname || nvram.wan3_ifname.length < 1)
+			select.options[2].disabled = 1;
+		if (!nvram.wan4_ifname || nvram.wan4_ifname.length < 1)
+			select.options[3].disabled = 1;
+	/* REMOVE-BEGIN */
+	}
+	/* REMOVE-END */
+	}
+}
+
+function updateTabLabel(u, ssid) {
+	var w = displayIfnameWithBand(u);
+	var tabName = (ssid ? ssid + '<br>' + w : w);
+	for (var i = 0; i < tabs.length; ++i) {
+		if (tabs[i][0] == u) {
+			tabs[i][1] = tabName;
+			break;
+		}
+	}
+	var tab = E(u);
+	if (tab)
+		tab.innerHTML = tabName;
+}
 
 var xob = null;
 var refresher = [];
@@ -60,6 +163,10 @@ var acphy = features('11ac');
 var ghz = [];
 var bands = [];
 var nm_loaded = [], ch_loaded = [], max_channel = [];
+var ssidHiddenStore = {};
+/* REMOVE-BEGIN */
+var hasMultiWan = ((typeof MAXWAN_NUM !== 'undefined') && (MAXWAN_NUM > 2));
+/* REMOVE-END */
 
 for (var uidx = 0; uidx < wl_ifaces.length; ++uidx) {
 	if (wl_sunit(uidx) < 0) {
@@ -113,12 +220,15 @@ wlg.populate = function() {
 				continue;
 
 			var wmode = (((vifs_defined[uidx][7]) == 'ap') && ((nvram['wl'+u+'_wds_enable']) == '1')) ? 'apwds': (vifs_defined[uidx][7]);
+			var bridgeValue = vifs_defined[uidx][11].toString();
+			if (wmode === 'sta' && (bridgeValue === '4' || bridgeValue === '' || typeof bridgeValue === 'undefined'))
+				bridgeValue = getWanIndex(vifs_defined[uidx][0]).toString();
 			this.insertData(-1, [
 				vifs_defined[uidx][0],
 				vifs_defined[uidx][4],
 				vifs_defined[uidx][8],
 				wmode,
-				vifs_defined[uidx][11].toString(),
+				bridgeValue,
 				vifs_defined[uidx][12].toString()
 			]);
 		}
@@ -154,38 +264,49 @@ REMOVE-END */
 		f[3].options[i].disabled = (f[3].options[i].value != 'ap');
 	}
 
-	if (nvram.lan_ifname.length < 1)
-		f[4].options[0].disabled = 1;
-	if (nvram.lan1_ifname.length < 1)
-		f[4].options[1].disabled = 1;
-	if (nvram.lan2_ifname.length < 1)
-		f[4].options[2].disabled = 1;
-	if (nvram.lan3_ifname.length < 1)
-		f[4].options[3].disabled = 1;
-
-	f[4].selectedIndex = 4;
+	setBridgeOptions(f[4], f[3].value, f[0].value);
+	if (f[3].value !== 'sta') {
+		if (nvram.lan_ifname.length < 1)
+			f[4].options[0].disabled = 1;
+		if (nvram.lan1_ifname.length < 1)
+			f[4].options[1].disabled = 1;
+		if (nvram.lan2_ifname.length < 1)
+			f[4].options[2].disabled = 1;
+		if (nvram.lan3_ifname.length < 1)
+			f[4].options[3].disabled = 1;
+	}
+	if (f[3].value !== 'sta')
+		f[4].selectedIndex = 4;
 	f[5].selectedIndex = 0;
 	ferror.clearAll(fields.getAll(this.newEditor));
 }
 
 wlg.dataToView = function(data) {
-	var ifname, uidx;
-	uidx = wl_ifidxx(data[0]);
-	if (uidx < 0)
-		ifname = 'wl'+data[0];
-	else
-		ifname = wl_display_ifname(uidx);
+	var ifname, bridge;
+	ifname = displayIfnameWithBand(data[0]);
+
+	if (data[3] === 'sta') {
+		var wanValue = data[4];
+		if (wanValue === '4' || wanValue === '' || typeof wanValue === 'undefined')
+			wanValue = getWanIndex(data[0]);
+		bridge = ['WAN0','WAN1','WAN2','WAN3','none'][wanValue * 1] || 'none';
+	} else {
+		bridge = ['LAN0 (br0)','LAN1 (br1)','LAN2 (br2)','LAN3 (br3)','none'][data[4] * 1] || 'none';
+	}
 
 	return ([ifname,(data[1] == 1) ? '&#x2b50' : '',
 	                 data[2] || '<small><i>(unset)<\/i><\/small>',
 	                 wmo[data[3]] || '<small><i>(unset)<\/i><\/small>',
-	                 ['LAN0 (br0)','LAN1 (br1)','LAN2 (br2)','LAN3 (br3)','none' ][data[4]],
+	                 bridge,
 	                 macmode[data[5]] || macmode[nvram['wl'+data[0].toString()+'_macmode']]
 	       ]);
 }
 
 wlg.dataToFieldValues = function (data) {
-	return ([data[0],(data[1] == '1') ? 'checked' : '',data[2],data[3],data[4],data[5]]);
+	var bridgeValue = data[4];
+	if (data[3] === 'sta' && (bridgeValue === '4' || bridgeValue === '' || typeof bridgeValue === 'undefined'))
+		bridgeValue = getWanIndex(data[0]);
+	return ([data[0],(data[1] == '1') ? 'checked' : '',data[2],data[3],bridgeValue,data[5]]);
 }
 
 wlg.fieldValuesToData = function(row) {
@@ -197,11 +318,15 @@ wlg.fieldValuesToData = function(row) {
 wlg.onDelete = function() {
 	this.removeEditor();
 	if (this.source._data[0].indexOf('.') > 0) {
-		var vif = definedVIFidx(this.source._data[0]);
+		var u = this.source._data[0];
+		var vif = definedVIFidx(u);
 		vifs_defined.splice(vif,1);
-		vifs_deleted.push(this.source._data[0]);
+		vifs_deleted.push(u);
 		elem.remove(this.source);
 		this.source = null;
+		updateTabVisibility();
+		if (cookie.get(cprefix+'_tab') == u)
+			tabSelect('overview');
 	}
 	else
 		this.showSource();
@@ -252,6 +377,7 @@ wlg.onAdd = function() {
 	]);
 
 	this.resort();
+	updateTabLabel(u, data[2]);
 	this.disableNewEditor(false);
 	this.resetNewEditor();
 
@@ -263,6 +389,7 @@ wlg.onAdd = function() {
 		}
 	}
 
+	updateTabVisibility();
 	tabSelect(u);
 	verifyFields(null, 1);
 
@@ -309,6 +436,7 @@ REMOVE-END */
 	vifs_defined[vif][7] = data[3]; /* WL mode */
 	vifs_defined[vif][11] = data[4]; /* LAN bridge */
 	vifs_defined[vif][12] = data[5]; /* Wireless Filter */
+	updateTabLabel(u, data[2]);
 /* REMOVE-BEGIN
 	alert(data.join('\n'));
 REMOVE-END */
@@ -344,14 +472,18 @@ wlg.verifyFields = function(row, quiet) {
 	var ok = 1;
 	var f = fields.getAll(row);
 
-	if (nvram.lan_ifname.length < 1)
-		f[4].options[0].disabled = 1;
-	if (nvram.lan1_ifname.length < 1)
-		f[4].options[1].disabled = 1;
-	if (nvram.lan2_ifname.length < 1)
-		f[4].options[2].disabled = 1;
-	if (nvram.lan3_ifname.length < 1)
-		f[4].options[3].disabled = 1;
+	setBridgeOptions(f[4], f[3].value, f[0].value);
+
+	if (f[3].value !== 'sta') {
+		if (nvram.lan_ifname.length < 1)
+			f[4].options[0].disabled = 1;
+		if (nvram.lan1_ifname.length < 1)
+			f[4].options[1].disabled = 1;
+		if (nvram.lan2_ifname.length < 1)
+			f[4].options[2].disabled = 1;
+		if (nvram.lan3_ifname.length < 1)
+			f[4].options[3].disabled = 1;
+	}
 
 	if (f[0].value.indexOf('.') < 0) {
 /* REMOVE-BEGIN
@@ -392,6 +524,15 @@ function definedVIFidx(vif) {
 	return -1;
 }
 
+function updateTabVisibility() {
+	for (var i = 1; i < tabs.length; ++i) {
+		var t = tabs[i][0];
+		var a = E(t);
+		if (!a) continue;
+		a.style.display = (definedVIFidx(t) >= 0) ? '' : 'none';
+	}
+}
+
 function tabSelect(name) {
 	if (wlg.isEditing())
 		return;
@@ -403,7 +544,15 @@ function tabSelect(name) {
 		E('footer-msg').style.display = 'none';
 
 	if (name == 'overview')
+	{
+		/* update tab labels from any open tab SSID edits so Overview shows current names */
+		for (var i = 1; i < tabs.length; ++i) {
+			var t = tabs[i][0];
+			var ss = E('_wl'+t+'_ssid');
+			if (ss && typeof ss.value !== 'undefined') updateTabLabel(t, ss.value);
+		}
 		wlg.populate();
+	}
 
 	elem.display('overview-tab', (name == 'overview'));
 	E('save-button').value = (name != 'overview') ? 'Overview' : 'Save';
@@ -455,7 +604,7 @@ function do_pre_submit_form(fom) {
 			var vif = definedVIFidx(u);
 			if (vif >= 0) {
 				for (var i = 0; i < elem.length ; ++i) {
-					if (elem[i].name.indexOf('wl'+u) == 0)
+					if (elem[i].name && elem[i].name.indexOf('wl'+u) == 0)
 						s += 'nvram set '+elem[i].name+'="'+elem[i].value+'"\n';
 				}
 			}
@@ -484,7 +633,7 @@ REMOVE-END */
 	for (var vidx = 0; vidx < vifs_deleted.length; ++vidx) {
 		var u = vifs_deleted[vidx];
 		for (var i = 0; i < elem.length ; ++i) {
-			if (elem[i].name.indexOf('wl'+u) == 0)
+			if (elem[i].name && elem[i].name.indexOf('wl'+u) == 0)
 				s += 'nvram unset '+elem[i].name+'\n';
 		}
 		lan_ifnames = lan_ifnames.replace('wl'+u, '');
@@ -517,6 +666,42 @@ REMOVE-END */
 		if (typeof(wl2_vifs) != 'undefined')
 			s += 'nvram set wl2_vifs="'+wl2_vifs+'"\n';
 	}
+
+	var staIface = '';
+	var staWan = 4;
+	for (var i = 0; i < vifs_defined.length; ++i) {
+		var u = vifs_defined[i][0];
+		if (typeof u == 'undefined')
+			continue;
+		var modeField = E('_f_wl'+u+'_mode');
+		var wmode = modeField ? modeField.value : vifs_defined[i][7];
+		if (wmode == 'sta') {
+			staIface = vifs_defined[i][1] || ('wl'+u);
+			/* prefer primary unit name for mapping (strip virtual subunit if present) */
+			if (staIface.indexOf('.') !== -1) staIface = staIface.split('.')[0];
+			staWan = vifs_defined[i][11];
+			break;
+		}
+	}
+	if (staIface) {
+		/* only set the specific WAN that needs the sta interface */
+		var effectiveIface = (staIface.indexOf('.') > -1) ? staIface.replace(/\.\d+$/, '') : staIface;
+		var wanPrefixes = ['wan', 'wan2', 'wan3', 'wan4'];
+		var targetIdx = (staWan * 1 >= 0 && staWan * 1 <= 3) ? staWan * 1 : -1;
+		if (targetIdx >= 0) {
+			/* strip sta iface from all WANs, then assign it to the target WAN */
+			for (var wi = 0; wi < wanPrefixes.length; ++wi) {
+				var curVal = nvram[wanPrefixes[wi]+'_ifname'];
+				if (!curVal) continue; /* skip undefined/empty - don't create new nvram entries */
+				var cleaned = stripIfname(curVal, staIface);
+				cleaned = stripIfname(cleaned, effectiveIface);
+				if (wi == targetIdx)
+					cleaned = effectiveIface;
+				if (cleaned !== curVal)
+					s += 'nvram set '+wanPrefixes[wi]+'_ifname="'+cleaned+'"\n';
+			}
+		}
+	}
 	post_pre_submit_form(s);
 }
 
@@ -529,6 +714,8 @@ function error_pre_submit_form() {
 	footermsg.innerHTML = '<tt>'+escapeText(cmdresult)+'<\/tt>';
 	footermsg.style.display = 'inline';
 
+	cmd = null;
+
 	cmdresult = '';
 }
 
@@ -538,10 +725,12 @@ function post_pre_submit_form(s) {
 
 	cmd = new XmlHttp();
 	cmd.onCompleted = function(text, xml) {
+		cmd = null;
 		form.submit(E('t_fom'), 1);
 	}
 	cmd.onError = function(x) {
 		cmdresult = 'ERROR: '+x;
+		cmd = null;
 		error_pre_submit_form();
 	}
 
@@ -618,7 +807,8 @@ function verifyFields(focused, quiet) {
 
 			_f_wl_lazywds: 1,
 			_f_wl_wds_0: 1,
-			_f_wl_macmode: 1
+			_f_wl_macmode: 1,
+			_f_wl_clap_hwaddr: 1
 			};
 		}
 		else {
@@ -662,7 +852,8 @@ REMOVE-END */
 
 			_f_wl_lazywds: 1,
 			_f_wl_wds_0: 1,
-			_f_wl_macmode: 1
+			_f_wl_macmode: 1,
+			_f_wl_clap_hwaddr: 1
 			};
 		}
 		wl_vis[vidx] = a;
@@ -674,6 +865,11 @@ REMOVE-END */
 			continue;
 
 		wmode = E('_f_wl'+u+'_mode').value;
+		E('wl'+u+'_mode_msg').style.display = (((wmode == 'sta') || (wmode == 'wet') ||
+/* BCMWL6-BEGIN */
+							(wmode == 'psta') ||
+/* BCMWL6-END */
+							0) ? 'inline' : 'none');
 
 		if (!E('_f_wl'+u+'_radio').checked) {
 			for (a in wl_vis[vidx]) {
@@ -687,15 +883,10 @@ REMOVE-END */
 			}
 		}
 
-		E('wl'+u+'_mode_msg').style.display = (((wmode == 'sta') || (wmode == 'wet') ||
-/* BCMWL6-BEGIN */
-							(wmode == 'psta') ||
-/* BCMWL6-END */
-							0) ? 'inline' : 'none');
-
 		switch (wmode) {
 			case 'apwds':
 			case 'wds':
+				wl_vis[vidx]._f_wl_clap_hwaddr = 0;
 			break;
 			case 'wet':
 /* BCMWL6-BEGIN */
@@ -703,14 +894,47 @@ REMOVE-END */
 /* BCMWL6-END */
 			case 'sta':
 				wl_vis[vidx]._f_wl_bcast = 0;
+				wl_vis[vidx]._f_wl_lazywds = 0;
+				wl_vis[vidx]._f_wl_wds_0 = 0;
+				wl_vis[vidx]._wl_net_mode = 0;
 				if (u.toString().indexOf('.') < 0) {
 					wl_vis[vidx]._wl_channel = 0;
 					wl_vis[vidx]._wl_nbw_cap = 0;
 				}
+				if (!E('_f_wl'+u+'_radio').checked) {
+					wl_vis[vidx]._f_wl_clap_hwaddr = 2;
+				}
+				else {
+					wl_vis[vidx]._f_wl_clap_hwaddr = 1;
+				}
+			break;
 			default:
 				wl_vis[vidx]._f_wl_lazywds = 0;
 				wl_vis[vidx]._f_wl_wds_0 = 0;
+				wl_vis[vidx]._f_wl_clap_hwaddr = 0;
 			break;
+		}
+
+		/* SSID scan button visibility - direct control because it's in a suffix */
+		var ssidScanBtn = E('_f_wl'+u+'_ssidscan');
+		if (ssidScanBtn) {
+			if (wmode == 'wet' || wmode == 'psta' || wmode == 'sta') {
+				ssidScanBtn.style.display = E('_f_wl'+u+'_radio').checked ? '' : 'none';
+			}
+			else {
+				ssidScanBtn.style.display = 'none';
+			}
+		}
+
+		/* Lock BSSID scan button visibility - direct control because it's in a suffix */
+		var macscanBtn = E('_f_wl'+u+'_macscan');
+		if (macscanBtn) {
+			if (wmode == 'wet' || wmode == 'psta' || wmode == 'sta') {
+				macscanBtn.style.display = E('_f_wl'+u+'_radio').checked ? '' : 'none';
+			}
+			else {
+				macscanBtn.style.display = 'none';
+			}
 		}
 
 		sm2 = E('_wl'+u+'_security_mode').value;
@@ -809,7 +1033,18 @@ REMOVE-END */
 				e.options[i].disabled = (e.options[i].value != 'ap');
 			}
 		}
-
+		var isClientMode = ((wmode == 'wet')
+	/* BCMWL6-BEGIN */
+			|| (wmode == 'psta')
+	/* BCMWL6-END */
+			|| (wmode == 'sta'));
+		var random1 = E('_f_wl'+u+'_psk_random1');
+		if (random1)
+			random1.style.display = isClientMode ? 'none' : '';
+		var random2 = E('_f_wl'+u+'_psk_random2');
+		if (random2)
+			random2.style.display = isClientMode ? 'none' : '';
+		/* mirror basic-network: map random controls visibility to PSK/radius_key so Disabled hides them */
 		wl_vis[vidx]._f_wl_psk_random1 = wl_vis[vidx]._wl_wpa_psk;
 		wl_vis[vidx]._f_wl_psk_random2 = wl_vis[vidx]._wl_radius_key;
 		wl_vis[vidx]._wl_radius_port = wl_vis[vidx]._wl_radius_ipaddr;
@@ -835,6 +1070,65 @@ REMOVE-END */
 			c = wl_vis[vidx][a];
 			b.disabled = (c != 1);
 			PR(b).style.display = (c ? 'table-row' : 'none');
+		}
+
+		/* Handle Broadcast SSID disabled: show '< hidden >' and grey out SSID field */
+		var broadcastEnabled = E('_f_wl'+u+'_bcast').checked;
+		if (!broadcastEnabled)
+			wl_vis[vidx]._wl_ssid = 2;
+		else if (wl_vis[vidx]._wl_ssid != 2)
+			wl_vis[vidx]._wl_ssid = 1;
+		var ssidElement = document.getElementsByName('wl'+u+'_ssid')[0];
+		if (ssidElement && !broadcastEnabled && ssidElement.tagName.toLowerCase() == 'select') {
+			ssidElement.outerHTML = '<input type="text" name="'+ssidElement.name+'" id="_wl'+u+'_ssid">';
+			ssidElement = document.getElementsByName('wl'+u+'_ssid')[0];
+		}
+		if (ssidElement) {
+			if (!broadcastEnabled) {
+				if (typeof ssidHiddenStore[u] === 'undefined')
+					ssidHiddenStore[u] = ssidElement.value;
+				ssidElement.value = ' < hidden >';
+				ssidElement.disabled = true;
+			}
+			else {
+				if (typeof ssidHiddenStore[u] !== 'undefined') {
+					ssidElement.value = ssidHiddenStore[u];
+					delete ssidHiddenStore[u];
+				}
+				ssidElement.disabled = false;
+			}
+		}
+	}
+
+	var clientModes = { 'sta': 1, 'wet': 1, 'psta': 1 };
+	for (var vidx = 0; vidx < vifs_possible.length; ++vidx) {
+		var u = vifs_possible[vidx][0];
+		if (definedVIFidx(u) < 0)
+			continue;
+		if (u.toString().indexOf('.') < 0)
+			continue;
+		var modeSelect = E('_f_wl'+u+'_mode');
+		if (!modeSelect)
+			continue;
+
+		var otherClient = false;
+		for (var other = 0; other < vifs_possible.length; ++other) {
+			var v = vifs_possible[other][0];
+			if (v == u)
+				continue;
+			if (definedVIFidx(v) < 0)
+				continue;
+			var otherMode = E('_f_wl'+v+'_mode').value;
+			if (clientModes[otherMode]) {
+				otherClient = true;
+				break;
+			}
+		}
+
+		for (var opt = 0; opt < modeSelect.options.length; ++opt) {
+			var option = modeSelect.options[opt];
+			if (clientModes[option.value])
+				option.disabled = otherClient;
 		}
 	}
 
@@ -989,6 +1283,22 @@ REMOVE-END */
 			}
 		}
 
+		/* RTNPLUS-BEGIN */
+		/* check MAC addr for wl client modes (sta/psta/wet) - try to connect to this AP */
+		a = E('_f_wl'+u+'_clap_hwaddr');
+		if (a) ferror.clear(a);
+		if (a && wl_vis[vidx]._f_wl_clap_hwaddr) {
+			if (a.value.length > 16) {
+				if (!v_mac(a, quiet || !ok))
+					ok = 0;
+			}
+			else if ((a.value.length > 0) && (a.value.length <= 16)) {
+				ferror.set(a, 'Invalid MAC address length', quiet || !ok);
+				ok = 0;
+			}
+		}
+		/* RTNPLUS-END */
+
 		ferror.clear('_f_wl'+u+'_macmode');
 		a = E('_f_wl'+u+'_macmode').value;
 		if (a != 'disabled' && a != 'deny' && a != 'allow') {
@@ -1053,14 +1363,21 @@ function save() {
 		u = vifs_possible[vidx][0].toString(); /* WL unit (primary) or unit.subunit (virtual) */
 		vif = definedVIFidx(u);
 
-		if (u == 0)
-			fom.wl_macmode.value = E('_f_wl'+u+'_macmode').value; /* rewrite for backward compatibility */
+		if (u == 0) {
+			var el = E('_f_wl'+u+'_macmode');
+			if (el) fom.wl_macmode.value = el.value; /* rewrite for backward compatibility */
+		}
 
-		if (vif < 0)
-			E('_wl'+u+'_macmode').name = '_f_wl'+u+'_macmode_'; /* use fake input name to delete */
+		if (vif < 0) {
+			var el = E('_wl'+u+'_macmode');
+			if (el) el.name = '_f_wl'+u+'_macmode_'; /* use fake input name to delete */
+		}
 		else {
-			E('_wl'+u+'_macmode').value = E('_f_wl'+u+'_macmode').value;
-			E('_wl'+u+'_maclist').value = nvram['wl_maclist'].toString(); /* copy base maclist to 'u' interface */
+			var el1 = E('_wl'+u+'_macmode');
+			var el2 = E('_f_wl'+u+'_macmode');
+			if (el1 && el2) el1.value = el2.value;
+			var el3 = E('_wl'+u+'_maclist');
+			if (el3) el3.value = nvram['wl_maclist'].toString(); /* copy base maclist to 'u' interface */
 		}
 /* REMOVE-BEGIN
 // AB TODO: try to play this safer - save some vital info on primary BSS (just in case?)
@@ -1071,13 +1388,19 @@ REMOVE-END */
 			b = 'wl'+u+'_';
 			for (i = 0; i < a.length; ++i) {
 				c = ''+b+a[i][0];
-				if (typeof(nvram[c]) != 'undefined')
-					E('_'+c).value = a[i][1];
+				if (typeof(nvram[c]) != 'undefined') {
+					var el = E('_'+c);
+					if (el) el.value = a[i][1];
+				}
 			}
 			continue;
 		}
 
-		if (vifs_defined[vif][11]*1 != 4) {
+		var modeForBridge = vifs_defined[vif][7];
+		var modeField = E('_f_wl'+u+'_mode');
+		if (modeField)
+			modeForBridge = modeField.value;
+		if (modeForBridge !== 'sta' && vifs_defined[vif][11]*1 != 4) {
 			var x = (vifs_defined[vif][11] == '0') ? '' : vifs_defined[vif][11].toString();
 			fom['lan'+x+'_ifnames'].value += ' '+vifs_defined[vif][1];
 			fom['lan'+x+'_ifnames'].value = fom['lan'+x+'_ifnames'].value.trim();
@@ -1101,9 +1424,14 @@ REMOVE-END */
 		else
 			E('_wl'+u+'_ifname').value = nvram['wl'+u+'_ifname'] || 'wl'+u;
 
-		wmode = E('_f_wl'+u+'_mode').value;
-		sm2 = E('_wl'+u+'_security_mode').value;
-		wradio = E('_f_wl'+u+'_radio').checked;
+		var el_mode = E('_f_wl'+u+'_mode');
+		var el_sec = E('_wl'+u+'_security_mode');
+		var el_radio = E('_f_wl'+u+'_radio');
+		if (!el_mode || !el_sec || !el_radio) continue;
+		
+		wmode = el_mode.value;
+		sm2 = el_sec.value;
+		wradio = el_radio.checked;
 
 		if (wmode == 'apwds')
 			E('_wl'+u+'_mode').value = 'ap';
@@ -1231,6 +1559,14 @@ REMOVE-END */
 
 		E('_wl'+u+'_closed').value = E('_f_wl'+u+'_bcast').checked ? 0 : 1;
 
+		/* Save clap_hwaddr for client modes */
+		if ((wmode == 'sta') || (wmode == 'wet') || (wmode == 'psta')) {
+			E('_wl'+u+'_clap_hwaddr').value = E('_f_wl'+u+'_clap_hwaddr').value;
+		}
+		else {
+			E('_wl'+u+'_clap_hwaddr').value = ''; /* clean up! */
+		}
+
 		a = fields.radio.selected(fom['f_wl'+u+'_wepidx']);
 /* REMOVE-BEGIN
 		if (a) E('_wl'+u+'_key').value = a.value;
@@ -1325,9 +1661,26 @@ function earlyInit() {
 			var s = (i == 0) ? '' : '.'+i.toString();
 			var t = u+s;
 			var v = wl_ifidxx(t);
-			var w = (v < 0 ? 'wl'+t : wl_display_ifname(v));
+			var w;
+			if (v < 0) {
+				/* virtual name not present in wl_ifaces - build base name and append band */
+				var base = 'wl'+t;
+				var pidx = wl_uidx(u);
+				var bandSuffix = '';
+				if (pidx >= 0) {
+					if (wl_bands[pidx].length == 1)
+						bandSuffix = (wl_bands[pidx][0] == '1') ? ' / 5 GHz' : ' / 2.4 GHz';
+					else
+						bandSuffix = (nvram['wl'+u+'_nband'] == 1) ? ' / 5 GHz' : ' / 2.4 GHz';
+				}
+				w = base + bandSuffix;
+			}
+			else
+				w = wl_display_ifname(v);
+			var ssid = nvram['wl'+t+'_ssid'] || '';
+			var tabName = (ssid ? ssid + '<br>' + w : w);
 			vifs_possible.push([t, w]);
-			tabs.push([t, w]);
+			tabs.push([t, tabName]);
 		}
 	}
 
@@ -1349,7 +1702,11 @@ function init() {
 		return;
 	}
 
-	tabSelect(cookie.get(cprefix+'_tab') || tabs[0][0]);
+	updateTabVisibility();
+	var desiredTab = cookie.get(cprefix+'_tab') || tabs[0][0];
+	if (desiredTab != 'overview' && definedVIFidx(desiredTab) < 0)
+		desiredTab = 'overview';
+	tabSelect(desiredTab);
 
 	var c;
 
@@ -1485,6 +1842,7 @@ function init() {
 				W('<input type="hidden" id="_wl'+u+'_ifname" name="wl'+u+'_ifname">');
 				W('<input type="hidden" id="_wl'+u+'_macmode" name="wl'+u+'_macmode">');
 				W('<input type="hidden" id="_wl'+u+'_maclist" name="wl'+u+'_maclist">');
+				W('<input type="hidden" id="_wl'+u+'_clap_hwaddr" name="wl'+u+'_clap_hwaddr">');
 
 /* only if primary VIF */
 				if (u.toString().indexOf('.') < 0) {
@@ -1507,17 +1865,17 @@ function init() {
 /* common to all VIFs */
 				var f = [];
 				f.push (
-					{ title: 'Enable Interface', name: 'f_wl'+u+'_radio', type: 'checkbox', value: (nvram['wl'+u+'_radio'] == '1' && nvram['wl'+u+'_net_mode'] != 'disabled') },
+					{ title: 'Enable', name: 'f_wl'+u+'_radio', type: 'checkbox', value: (nvram['wl'+u+'_radio'] == '1' && nvram['wl'+u+'_net_mode'] != 'disabled') },
 					{ title: 'AP Isolation', name: 'f_wl'+u+'_ap_isolate', type: 'checkbox', value: nvram['wl'+u+'_ap_isolate'] == '1' },
 					{ title: 'MAC Address', text: '<a href="advanced-mac.asp">'+(nvram['wl'+u+'_hwaddr'] || mac_null)+'<\/a>'+' &nbsp; <b id="wl'+u+'_hwaddr_msg" style="display:none"><small>(warning: WL driver reports BSSID <a href="advanced-mac.asp">'+((typeof(wl_ifaces[wl_ifidxx(u)]) != 'undefined') ? wl_ifaces[wl_ifidxx(u)][9] : '')+'<\/a>)<\/small><\/b>' },
-					{ title: 'Wireless Mode', name: 'f_wl'+u+'_mode', type: 'select', options: wl_modes_available, value: (nvram['wl'+u+'_mode'] == 'ap' && nvram['wl'+u+'_wds_enable'] == '1') ? 'apwds' : nvram['wl'+u+'_mode'], suffix: ' &nbsp; <b id="wl'+u+'_mode_msg" style="display:none"><small>(note: you might wish to cross-check settings later on <a href="basic-network.asp">Basic/Network<\/a>)<\/small><\/b>' }
+					{ title: 'Wireless Mode', name: 'f_wl'+u+'_mode', type: 'select', options: wl_modes_available, value: (nvram['wl'+u+'_mode'] == 'ap' && nvram['wl'+u+'_wds_enable'] == '1') ? 'apwds' : nvram['wl'+u+'_mode'], suffix:  ' <span id="wl'+u+'_mode_msg" style="display:none"><small> Cross check settings on <a href="basic-network.asp">Basic/Network<\/a><\/small><\/span>' }
 				);
 
 /* only if primary VIF */
 				if (u.toString().indexOf('.') < 0) {
 					f.push (
-						{ title: 'Radio Band', name: 'f_wl'+u+'_nband', type: 'select', options: bands[uidx], value: (nvram['wl'+u+'_nband'] || '0' == '0') ? bands[uidx][0][0] : nvram['wl'+u+'_nband'] },
-						{ title: 'Wireless Network Mode', name: 'wl'+u+'_net_mode', type: 'select', value: (nvram['wl'+u+'_net_mode'] == 'disabled') ? 'mixed' : nvram['wl'+u+'_net_mode'], options: [], prefix: '<span id="__wl'+u+'_net_mode">', suffix: '<\/span>' }
+						{ title: 'Radio Band', indent: 2, name: 'f_wl'+u+'_nband', type: 'select', options: bands[uidx], value: (nvram['wl'+u+'_nband'] || '0' == '0') ? bands[uidx][0][0] : nvram['wl'+u+'_nband'] },
+						{ title: 'Wireless Network Mode', indent: 2, name: 'wl'+u+'_net_mode', type: 'select', value: (nvram['wl'+u+'_net_mode'] == 'disabled') ? 'mixed' : nvram['wl'+u+'_net_mode'], options: [], prefix: '<span id="__wl'+u+'_net_mode">', suffix: '<\/span>' }
 					);
 				}
 
@@ -1525,16 +1883,19 @@ function init() {
 					nvram['wl'+u+'_closed'] = '0';
 
 				f.push (
-					{ title: 'SSID', name: 'wl'+u+'_ssid', type: 'text', maxlen: 32, size: 34, value: nvram['wl'+u+'_ssid'] },
-					{ title: 'Broadcast', indent: 2, name: 'f_wl'+u+'_bcast', type: 'checkbox', value: nvram['wl'+u+'_closed'] == '0' }
+					{ title: 'Broadcast SSID', indent: 2, name: 'f_wl'+u+'_bcast', type: 'checkbox', value: nvram['wl'+u+'_closed'] == '0' },
+					{ title: 'SSID', indent: 2, name: 'wl'+u+'_ssid', type: 'text', maxlen: 32, size: 34, value: nvram['wl'+u+'_ssid'], placeholder: ' < case sensitive >', prefix: '<span id="__wl'+u+'_ssid">', suffix: '<\/span> <input type="button" id="_f_wl'+u+'_ssidscan" value="Scan" onclick="scanButton('+u+', \'ssid\')" style="width:auto"> <img src="spin.svg" alt="" id="spinSsid'+u+'" style="display:none;"> <select id="ssidList'+u+'" style="display:none" onchange="selectSsid(this, '+u+')"><\/select>', onchange: 'clearBssidIfPresent('+u+')' },
+/* RTNPLUS-BEGIN */
+					{ title: 'BSSID lock', indent: 2, name: 'f_wl'+u+'_clap_hwaddr', type: 'text', placeholder: ' < optional >', maxlen: 17, size: 20, value: nvram['wl'+u+'_clap_hwaddr'], suffix: ' <input type="button" id="_f_wl'+u+'_macscan" value="Scan" title="Predefined SSID only" onclick="scanBSSID('+u+')" style="display:none"> <img src="spin.svg" alt="" id="spinMac'+u+'" style="display:none;"> <small> Defined SSID only<\/small>' }
+/* RTNPLUS-END */
 				);
 
 /* only if primary VIF */
 				if (u.toString().indexOf('.') < 0) {
 					f.push (
-						{ title: 'Channel', name: 'wl'+u+'_channel', type: 'select', options: ghz[uidx], prefix: '<span id="__wl'+u+'_channel">', suffix: '<\/span> <input type="button" id="_f_wl'+u+'_scan" value="Scan" onclick="scanButton('+u+')"> <img src="spin.svg" alt="" id="spin'+u+'">', value: nvram['wl'+u+'_channel'] },
-						{ title: 'Channel Width', name: 'wl'+u+'_nbw_cap', type: 'select', options: [], value: nvram['wl'+u+'_nbw_cap'], prefix: '<span id="__wl'+u+'_nbw_cap">', suffix: '<\/span>' },
-						{ title: 'Control Sideband', name: 'f_wl'+u+'_nctrlsb', type: 'select', options: [['lower','Lower'],['upper','Upper']], value: (nvram['wl'+u+'_nctrlsb'] == 'none') ? 'lower' : nvram['wl'+u+'_nctrlsb'] }
+						{ title: 'Channel', indent: 2, name: 'wl'+u+'_channel', type: 'select', options: ghz[uidx], prefix: '<span id="__wl'+u+'_channel">', suffix: '<\/span> <input type="button" id="_f_wl'+u+'_scan" value="Scan" onclick="scanButton('+u+')"> <img src="spin.svg" alt="" id="spin'+u+'">', value: nvram['wl'+u+'_channel'] },
+						{ title: 'Channel Width', indent: 2, name: 'wl'+u+'_nbw_cap', type: 'select', options: [], value: nvram['wl'+u+'_nbw_cap'], prefix: '<span id="__wl'+u+'_nbw_cap">', suffix: '<\/span>' },
+						{ title: 'Control Sideband', indent: 2, name: 'f_wl'+u+'_nctrlsb', type: 'select', options: [['lower','Lower'],['upper','Upper']], value: (nvram['wl'+u+'_nctrlsb'] == 'none') ? 'lower' : nvram['wl'+u+'_nctrlsb'] }
 					);
 				}
 
@@ -1545,11 +1906,11 @@ function init() {
 					null,
 					{ title: '<a href="basic-wfilter.asp" class="new_window">Wireless Filter<\/a>', name: 'f_wl'+u+'_macmode', type: 'select', options: [['disabled','Disable filter on that interface'],['deny','Block clients from the list on that interface'],['allow','Permit only clients from the list on that interface']], value: nvram['wl'+u+'_macmode'] },
 					null,
-					{ title: 'Security', name: 'wl'+u+'_security_mode', type: 'select', options: [['disabled','Disabled'],['wep','WEP'],['wpa_personal','WPA Personal'],['wpa_enterprise','WPA Enterprise'],['wpa2_personal','WPA2 Personal'],['wpa2_enterprise','WPA2 Enterprise'],['wpaX_personal','WPA / WPA2 Personal'],['wpaX_enterprise','WPA / WPA2 Enterprise'],['radius','Radius']], value: nvram['wl'+u+'_security_mode'] },
+					{ title: 'Security', name: 'wl'+u+'_security_mode', type: 'select', options: [['disabled','Disabled'],['wep','WEP'],['wpa_personal','WPA Personal'],['wpa_enterprise','WPA Enterprise'],['wpa2_personal','WPA2 Personal'],['wpa2_enterprise','WPA2 Enterprise'],['wpaX_personal','WPA / WPA2 Personal'],['wpaX_enterprise','WPA / WPA2 Enterprise'],['radius','Radius']], value: nvram['wl'+u+'_security_mode'], onchange: 'verifyFields(null,1)' },
 					{ title: 'Encryption', indent: 2, name: 'wl'+u+'_crypto', type: 'select', options: [['tkip','TKIP'],['aes','AES'],['tkip+aes','TKIP / AES']], value: nvram['wl'+u+'_crypto'] },
-					{ title: 'Shared Key', indent: 2, name: 'wl'+u+'_wpa_psk', type: 'password', maxlen: 64, size: 66, peekaboo: 1,
-						suffix: ' <input type="button" id="_f_wl'+u+'_psk_random1" value="Random" onclick="random_psk(\'_wl'+u+'_wpa_psk\')">', value: nvram['wl'+u+'_wpa_psk'] },
-					{ title: 'Shared Key', indent: 2, name: 'wl'+u+'_radius_key', type: 'password', maxlen: 80, size: 32, peekaboo: 1, suffix: ' <input type="button" id="_f_wl'+u+'_psk_random2" value="Random" onclick="random_psk(\'_wl'+u+'_radius_key\')">', value: nvram['wl'+u+'_radius_key'] },
+					{ title: 'Shared Key', indent: 2, name: 'wl'+u+'_wpa_psk', type: 'password', maxlen: 63, size: 34, peekaboo: 1, placeholder: ' < case sensitive >',
+						suffix: ' <select id="_f_wl'+u+'_psk_random1" onchange="random_psk(\'_wl'+u+'_wpa_psk\', \'_f_wl'+u+'_psk_random1\')" style="width:auto"><option value="default" style="color:grey" selected>Random</option><option value="clear">Clear</option><option value="8">8 chars</option><option value="10">10 chars</option><option value="12">12 chars</option><option value="14">14 chars</option><option value="16">16 chars</option><option value="18">18 chars</option><option value="24">24 chars</option><option value="32">32 chars</option><option value="48">48 chars</option><option value="63">63 chars</option></select>', value: nvram['wl'+u+'_wpa_psk'] },
+					{ title: 'Shared Key', indent: 2, name: 'wl'+u+'_radius_key', type: 'password', maxlen: 80, size: 32, peekaboo: 1, placeholder: ' < case sensitive >', suffix: ' <select id="_f_wl'+u+'_psk_random2" onchange="random_psk(\'_wl'+u+'_radius_key\', \'_f_wl'+u+'_psk_random2\')" style="width:auto"><option value="default" style="color:grey" selected>Random</option><option value="clear">Clear</option><option value="8">8 chars</option><option value="10">10 chars</option><option value="12">12 chars</option><option value="16">16 chars</option><option value="24">24 chars</option><option value="32">32 chars</option><option value="48">48 chars</option><option value="63">63 chars</option></select>', value: nvram['wl'+u+'_radius_key'] },
 					{ title: 'Group Key Renewal', indent: 2, name: 'wl'+u+'_wpa_gtk_rekey', type: 'text', maxlen: 7, size: 9, suffix: '&nbsp; <small>seconds<\/small>', value: (nvram['wl'+u+'_wpa_gtk_rekey'] || '3600') },
 					{ title: 'Radius Server', indent: 2, multi: [
 						{ name: 'wl'+u+'_radius_ipaddr', type: 'text', maxlen: 15, size: 17, value: nvram['wl'+u+'_radius_ipaddr'] },
@@ -1566,7 +1927,7 @@ function init() {
 						{ title: ('Key '+j), indent: 2, name: ('wl'+u+'_key'+j), type: 'text', maxlen: 26, size: 34, suffix: '&nbsp;<input type="radio" onchange="verifyFields(this,1)" onclick="verifyFields(this,1)" name="f_wl'+u+'_wepidx" id="_f_wl'+u+'_wepidx_'+j+'" value="'+j+'"'+((nvram['wl'+u+'_key'] == j) ? ' checked>' : '>'), value: nvram['wl'+u+'_key'+j] });
 				}
 
-				f.push(null, { title: 'WDS', name: 'f_wl'+u+'_lazywds', type: 'select', options: [['0','Link With...'],['1','Automatic']], value: nvram['wl'+u+'_lazywds'] } );
+				f.push(null, { title: 'WDS peering policy', name: 'f_wl'+u+'_lazywds', type: 'select', options: [['0','Restricted'],['1','Open']], value: nvram['wl'+u+'_lazywds'], onchange: 'verifyFields(null,1)' } );
 
 				var wds = nvram['wl'+u+'_wds'];
 				if (typeof(wds) == 'undefined')

--- a/release/src-rt-6.x.4708/router/www/basic-network.asp
+++ b/release/src-rt-6.x.4708/router/www/basic-network.asp
@@ -24,6 +24,19 @@
 //	<% nvram("dhcp_lease,dhcpd_startip,dhcpd_endip,lan_dhcp,lan_gateway,lan_ipaddr,lan_netmask,lan_proto,lan_state,lan_desc,lan_invert,wl_security_mode,wl_wds_enable,wl_channel,wl_closed,wl_crypto,wl_key,wl_key1,wl_key2,wl_key3,wl_key4,wl_clap_hwaddr,wl_lazywds,wl_mode,wl_net_mode,wl_passphrase,wl_radio,wl_radius_ipaddr,wl_radius_port,wl_ssid,wl_wds,wl_wep_bit,wl_wpa_gtk_rekey,wl_wpa_psk,wl_radius_key,wl_auth,wl_hwaddr,t_features,wl_nbw_cap,wl_nctrlsb,wl_nband,wl_phytype,lan_ifname,lan_stp,cstats_enable,wan_proto,wan_weight,wan_modem_type,wan_modem_pin,wan_modem_dev,wan_modem_init,wan_modem_apn,wan_modem_speed,wan_modem_band,wan_modem_roam,wan_ppp_username,wan_ppp_passwd,wan_ppp_service,wan_l2tp_server_ip,wan_pptp_dhcp,wan_ipaddr,wan_netmask,wan_gateway,wan_pptp_server_ip,wan_ppp_custom,wan_ppp_demand,wan_ppp_idletime,wan_ppp_demand_dnsip,wan_ppp_redialperiod,wan_pppoe_lei,wan_pppoe_lef,wan_mtu_enable,wan_mtu,wan_ppp_mlppp,wan_modem_ipaddr,wan_sta,wan_dns,wan_dns_auto,wan_ifnameX,wan_ckmtd,wan_ck_pause,mwan_num,mwan_cktime,mwan_ckdst,mwan_tune_gc,wan_hilink_ip,wan_status_script,dnscrypt_proxy,dnscrypt_priority,stubby_proxy,stubby_priority,dhcp_moveip,smart_connect_x"); %>
 
 var sta_list = [];
+/* REMOVE-BEGIN */
+if (nvram['usb_support'] == '1') {
+    var hasUsbSupport = true;
+} else {
+    var hasUsbSupport = false;
+}
+
+if (typeof MAXWAN_NUM !== 'undefined' && MAXWAN_NUM > 2) {
+    var hasMultiWan = true;
+} else {
+    var hasMultiWan = false;
+}
+/* REMOVE-END */
 function refresh_sta_list() {
 	var u, wluidx, staidx = 0;
 /* RTAC-NO-BEGIN */
@@ -39,7 +52,9 @@ function refresh_sta_list() {
 /* RTAC-NO-END */
 	/* And finally - Add Option "Disabled" */
 	sta_list[staidx] = [];
-	sta_list[staidx][0] = '';
+	sta_list[staidx][0] = ''; 
+	sta_list[staidx][1] = 'Disabled';
+	sta_list[staidx][2] = 'SSID: ' + nvram['wl'+u+'_ssid'];
 	sta_list[staidx][1] = 'Disabled';
 }
 
@@ -51,7 +66,7 @@ lg.setup = function() {
 		{ type: 'text', maxlen: 15, size: 17 },
 		{ type: 'text', maxlen: 15, size: 17 },
 		{ type: 'checkbox', prefix: '<div class="centered">', suffix: '<\/div>' },
-		{ multi: [ { type: 'text', maxlen: 15, size: 17}, { type: 'text', maxlen: 15, size: 17 } ] },
+		{ multi: [ { type: 'text', maxlen: 15, size: 17 }, { type: 'text', maxlen: 15, size: 17 } ] },
 		{ type: 'text', maxlen: 6, size: 8 }] );
 	this.headerSet(['Bridge','STP','IP Address','Netmask','DHCP','IP&nbsp;Range&nbsp;<i>(first/last)<\/i>','Lease&nbsp;Time&nbsp;<i>(mins)<\/i>']);
 
@@ -67,8 +82,8 @@ lg.setup = function() {
 					nvram['dhcpd'+j+'_endip'] = getAddress('0.0.0.50', n);
 				}
 			}
-			lg.insertData(-1, [i.toString(), nvram['lan'+j+'_stp'], nvram['lan'+j+'_ipaddr'], nvram['lan'+j+'_netmask'], (nvram['lan'+j+'_proto'] == 'dhcp') ? 1 : 0, nvram['dhcpd'+j+'_startip'], 
-			                   nvram['dhcpd'+j+'_endip'], (nvram['lan'+j+'_proto'] == 'dhcp') ? (((nvram['dhcp'+j+'_lease']) * 1 == 0) ? '1440' : (nvram['dhcp'+j+'_lease']).toString()) : '']) ;
+			lg.insertData(-1, [i.toString(), nvram['lan'+j+'_stp'], nvram['lan'+j+'_ipaddr'], nvram['lan'+j+'_netmask'], (nvram['lan'+j+'_proto'] == 'dhcp') ? 1 : 0, nvram['dhcpd'+j+'_startip'],
+							   nvram['dhcpd'+j+'_endip'], (nvram['lan'+j+'_proto'] == 'dhcp') ? (((nvram['dhcp'+j+'_lease']) * 1 == 0) ? '1440' : (nvram['dhcp'+j+'_lease']).toString()) : '']) ;
 			numBridges++;
 		}
 	}
@@ -97,9 +112,9 @@ lg.fieldValuesToData = function(row) {
 	return [f[0].value, f[1].checked ? 1 : 0, f[2].value, f[3].value, f[4].checked ? 1 : 0, f[5].value, f[6].value, f[7].value];
 }
 
-lg.resetNewEditor = function() {
-	var f = fields.getAll(this.newEditor);
-	f[0].selectedIndex=0;
+	lg.resetNewEditor = function() {
+		var f = fields.getAll(this.newEditor);
+		f[0].selectedIndex=0;
 
 	var t = MAX_BRIDGE_ID;
 	while ((this.countBridge(f[0].selectedIndex) > 0) && (t > 0)) {
@@ -226,7 +241,7 @@ lg.verifyFields = function(row, quiet) {
 	else
 		ferror.clear(f[0]);
 /* valid IP address? */
-	if (!v_ip(f[2], quiet || !ok)) 
+	if (!v_ip(f[2], quiet || !ok))
 		ok = 0;
 /* if we have a properly defined IP address - 0.0.0.0 is NOT a valid IP address for our intents/purposes! */
 	if ((f[2].value != '') && (f[2].value != '0.0.0.0')) {
@@ -308,9 +323,9 @@ lg.verifyFields = function(row, quiet) {
 		}
 /* first IP valid? */
 		if ((getNetworkAddress(f[5].value, f[3].value) != getNetworkAddress(f[2].value, f[3].value)) ||
-		    (f[5].value == getBroadcastAddress(getNetworkAddress(f[2].value, f[3].value), f[3].value)) ||
-		    (f[5].value == getNetworkAddress(f[2].value, f[3].value)) ||
-		    (f[2].value == f[5].value)) {
+			(f[5].value == getBroadcastAddress(getNetworkAddress(f[2].value, f[3].value), f[3].value)) ||
+			(f[5].value == getNetworkAddress(f[2].value, f[3].value)) ||
+			(f[2].value == f[5].value)) {
 			ferror.set(f[5], 'Invalid first IP address or subnet mask', quiet || !ok);
 			return 0;
 		}
@@ -318,9 +333,9 @@ lg.verifyFields = function(row, quiet) {
 			ferror.clear(f[5]);
 /* last IP valid? */
 		if ((getNetworkAddress(f[6].value, f[3].value) != getNetworkAddress(f[2].value, f[3].value)) ||
-		    (f[6].value == getBroadcastAddress(getNetworkAddress(f[2].value, f[3].value), f[3].value)) ||
-		    (f[6].value == getNetworkAddress(f[2].value, f[3].value)) ||
-		    (f[2].value == f[6].value)) {
+			(f[6].value == getBroadcastAddress(getNetworkAddress(f[2].value, f[3].value), f[3].value)) ||
+			(f[6].value == getNetworkAddress(f[2].value, f[3].value)) ||
+			(f[2].value == f[6].value)) {
 			ferror.set(f[6], 'Invalid last IP address or subnet mask', quiet || !ok);
 			return 0;
 		}
@@ -335,7 +350,7 @@ lg.verifyFields = function(row, quiet) {
 /* lease time */
 		if (parseInt(f[7].value*1) == 0)
 			f[7].value = 1440; /* from nvram/defaults.c */
-		if (!v_mins(f[7], quiet || !ok, 1, 10080)) 
+		if (!v_mins(f[7], quiet || !ok, 1, 10080))
 			ok = 0;
 	}
 	else {
@@ -369,6 +384,7 @@ var acphy = features('11ac');
 var ghz = [];
 var bands = [];
 var nm_loaded = [], ch_loaded = [], max_channel = [];
+var ssidHiddenStore = {};
 
 for (var uidx = 0; uidx < wl_ifaces.length; ++uidx) {
 	if (wl_sunit(uidx) < 0) {
@@ -457,8 +473,14 @@ function verifyFields(focused, quiet) {
 			vis['_wan'+u+'_netmask'] = 1;
 			vis['_wan'+u+'_gateway'] = 1;
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 			vis['_wan'+u+'_hilink_ip'] = 1;
 			vis['_f_wan'+u+'_status_script'] = 1;
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 			vis['_wan'+u+'_ckmtd'] = 1;
 			vis['_f_wan'+u+'_ck_pause'] = 1;
@@ -477,6 +499,9 @@ function verifyFields(focused, quiet) {
 /* SIZEOPTMORE-END */
 			vis['_wan'+u+'_modem_ipaddr'] = 1;
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 			vis['_wan'+u+'_modem_pin'] = 1;
 			vis['_wan'+u+'_modem_dev'] = 1;
 			vis['_wan'+u+'_modem_init'] = 1;
@@ -484,6 +509,9 @@ function verifyFields(focused, quiet) {
 			vis['_wan'+u+'_modem_speed'] = 1;
 			vis['_wan'+u+'_modem_band'] = 1;
 			vis['_wan'+u+'_modem_roam'] = 1;
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 			vis['_wan'+u+'_sta'] = 1;
 			vis['_f_wan'+u+'_dns_1'] = 1;
@@ -500,8 +528,14 @@ function verifyFields(focused, quiet) {
 			E('_wan'+u+'_netmask').disabled = 0;
 			E('_wan'+u+'_gateway').disabled = 0;
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 			E('_wan'+u+'_hilink_ip').disabled = 0;
 			E('_f_wan'+u+'_status_script').disabled = 0;
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 			E('_wan'+u+'_ckmtd').disabled = 0;
 			E('_f_wan'+u+'_ck_pause').disabled = 0;
@@ -520,6 +554,9 @@ function verifyFields(focused, quiet) {
 /* SIZEOPTMORE-END */
 			E('_wan'+u+'_modem_ipaddr').disabled = 0;
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 			E('_wan'+u+'_modem_pin').disabled = 0;
 			E('_wan'+u+'_modem_dev').disabled = 0;
 			E('_wan'+u+'_modem_init').disabled = 0;
@@ -527,6 +564,9 @@ function verifyFields(focused, quiet) {
 			E('_wan'+u+'_modem_speed').disabled = 0;
 			E('_wan'+u+'_modem_band').disabled = 0;
 			E('_wan'+u+'_modem_roam').disabled = 0;
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 			E('_wan'+u+'_sta').disabled = 0;
 			E('_f_wan'+u+'_dns_1').disabled = 0;
@@ -562,6 +602,9 @@ function verifyFields(focused, quiet) {
 /* SIZEOPTMORE-END */
 			vis['_wan'+u+'_modem_ipaddr'] = 0;
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 			vis['_wan'+u+'_modem_pin'] = 0;
 			vis['_wan'+u+'_modem_dev'] = 0;
 			vis['_wan'+u+'_modem_init'] = 0;
@@ -569,6 +612,9 @@ function verifyFields(focused, quiet) {
 			vis['_wan'+u+'_modem_speed'] = 0;
 			vis['_wan'+u+'_modem_band'] = 0;
 			vis['_wan'+u+'_modem_roam'] = 0;
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 			vis['_wan'+u+'_sta'] = 0;
 			vis['_f_wan'+u+'_dns_1'] = 0;
@@ -585,8 +631,14 @@ function verifyFields(focused, quiet) {
 			E('_wan'+u+'_netmask').disabled = 1;
 			E('_wan'+u+'_gateway').disabled = 1;
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 			E('_wan'+u+'_hilink_ip').disabled = 1;
 			E('_f_wan'+u+'_status_script').disabled = 1;
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 			E('_wan'+u+'_ckmtd').disabled = 1;
 			E('_f_wan'+u+'_ck_pause').disabled = 1;
@@ -605,6 +657,9 @@ function verifyFields(focused, quiet) {
 /* SIZEOPTMORE-END */
 			E('_wan'+u+'_modem_ipaddr').disabled = 1;
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 			E('_wan'+u+'_modem_pin').disabled = 1;
 			E('_wan'+u+'_modem_dev').disabled = 1;
 			E('_wan'+u+'_modem_init').disabled = 1;
@@ -612,6 +667,9 @@ function verifyFields(focused, quiet) {
 			E('_wan'+u+'_modem_speed').disabled = 1;
 			E('_wan'+u+'_modem_band').disabled = 1;
 			E('_wan'+u+'_modem_roam').disabled = 1;
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 			E('_f_wan'+u+'_dns_1').disabled = 1;
 			E('_f_wan'+u+'_dns_2').disabled = 1;
@@ -667,26 +725,34 @@ function verifyFields(focused, quiet) {
 
 			if ((wmode == 'wet')
 /* BCMWL6-BEGIN */
-			    || (wmode == 'psta')
+				|| (wmode == 'psta')
 /* BCMWL6-END */
-			   ) {
+			) {
+				if (!window._wanProtoBackup) window._wanProtoBackup = [];
 				E('_mwan_num').value = 1;
 				E('_mwan_cktime').value = 0;
 				elem.display('mwan-title', 'mwan-section', 0);
 				for (wan_uidx = 1; wan_uidx <= MAXWAN_NUM; ++wan_uidx) {
 					u = (wan_uidx > 1) ? wan_uidx : '';
 					vis['_wan'+u+'_proto'] = 0;
+					if (typeof window._wanProtoBackup[wan_uidx - 1] === 'undefined')
+						window._wanProtoBackup[wan_uidx - 1] = wanproto[wan_uidx - 1];
 					E('_wan'+u+'_proto').value = 'disabled';
 					wanproto[wan_uidx - 1] = 'disabled';
 					elem.display('wan'+u+'-title', 'sesdiv_wan'+u, 0);
 				}
-				break; /* break the loop! one wlan module is using wireless ethernet bridge or media bridge mode --> hide wan options! */
+				break; /* break the loop! one wlan module is using wireless ethernet bridge or media bridge mode -> hide wan options! */
 			}
 			else { /* not in wireless bridge mode - show wan options */
 				elem.display('mwan-title', 'mwan-section', 1);
 				for (wan_uidx = 1; wan_uidx <= curr_mwan_num; ++wan_uidx) {
 					u = (wan_uidx > 1) ? wan_uidx : '';
 					vis['_wan'+u+'_proto'] = 1;
+					if (window._wanProtoBackup && (typeof window._wanProtoBackup[wan_uidx - 1] !== 'undefined')) {
+						wanproto[wan_uidx - 1] = window._wanProtoBackup[wan_uidx - 1];
+						E('_wan'+u+'_proto').value = window._wanProtoBackup[wan_uidx - 1];
+						window._wanProtoBackup[wan_uidx - 1] = undefined;
+					}
 					elem.display('wan'+u+'-title', 'sesdiv_wan'+u, 1);
 				}
 			}
@@ -707,8 +773,14 @@ function verifyFields(focused, quiet) {
 			vis['_wan'+u+'_netmask'] = 0;
 			vis['_wan'+u+'_gateway'] = 0;
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 			vis['_wan'+u+'_hilink_ip'] = 0;
 			vis['_f_wan'+u+'_status_script'] = 0;
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 			vis['_wan'+u+'_ckmtd'] = 0;
 			vis['_f_wan'+u+'_ck_pause'] = 0;
@@ -722,6 +794,9 @@ function verifyFields(focused, quiet) {
 /* SIZEOPTMORE-END */
 			vis['_wan'+u+'_modem_ipaddr'] = 0;
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 			vis['_wan'+u+'_modem_pin'] = 0;
 			vis['_wan'+u+'_modem_dev'] = 0;
 			vis['_wan'+u+'_modem_init'] = 0;
@@ -729,6 +804,9 @@ function verifyFields(focused, quiet) {
 			vis['_wan'+u+'_modem_speed'] = 0;
 			vis['_wan'+u+'_modem_band'] = 0;
 			vis['_wan'+u+'_modem_roam'] = 0;
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 			vis['_wan'+u+'_pppoe_lei'] = 0;
 			vis['_wan'+u+'_pppoe_lef'] = 0;
@@ -755,6 +833,9 @@ function verifyFields(focused, quiet) {
 			vis['_f_wan'+u+'_ppp_mlppp'] = 0;
 /* SIZEOPTMORE-END */
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 			vis['_wan'+u+'_modem_pin'] = 0;
 			vis['_wan'+u+'_modem_dev'] = 0;
 			vis['_wan'+u+'_modem_init'] = 0;
@@ -762,6 +843,9 @@ function verifyFields(focused, quiet) {
 			vis['_wan'+u+'_modem_speed'] = 0;
 			vis['_wan'+u+'_modem_band'] = 0;
 			vis['_wan'+u+'_modem_roam'] = 0;
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 		break;
 		case 'pppoe':
@@ -771,6 +855,9 @@ function verifyFields(focused, quiet) {
 			vis['_wan'+u+'_ipaddr'] = 0;
 			vis['_wan'+u+'_netmask'] = 0;
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 			vis['_wan'+u+'_modem_pin'] = 0;
 			vis['_wan'+u+'_modem_dev'] = 0;
 			vis['_wan'+u+'_modem_init'] = 0;
@@ -778,6 +865,9 @@ function verifyFields(focused, quiet) {
 			vis['_wan'+u+'_modem_speed'] = 0;
 			vis['_wan'+u+'_modem_band'] = 0;
 			vis['_wan'+u+'_modem_roam'] = 0;
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 		break;
 /* USB-BEGIN */
@@ -790,9 +880,15 @@ function verifyFields(focused, quiet) {
 			vis['_wan'+u+'_ipaddr'] = 0;
 			vis['_wan'+u+'_netmask'] = 0;
 			vis['_wan'+u+'_modem_ipaddr'] = 0;
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 			vis['_wan'+u+'_modem_speed'] = 0;
 			vis['_wan'+u+'_modem_band'] = 0;
 			vis['_wan'+u+'_modem_roam'] = 0;
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* SIZEOPTMORE-BEGIN */
 			vis['_f_wan'+u+'_ppp_mlppp'] = 0;
 /* SIZEOPTMORE-END */
@@ -813,8 +909,14 @@ function verifyFields(focused, quiet) {
 			vis['_wan'+u+'_ipaddr'] = 0;
 			vis['_wan'+u+'_netmask'] = 0;
 			vis['_wan'+u+'_modem_ipaddr'] = 0;
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 			vis['_wan'+u+'_modem_dev'] = 0;
 			vis['_wan'+u+'_modem_init'] = 0;
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* SIZEOPTMORE-BEGIN */
 			vis['_f_wan'+u+'_ppp_mlppp'] = 0;
 /* SIZEOPTMORE-END */
@@ -836,6 +938,9 @@ function verifyFields(focused, quiet) {
 			vis['_f_wan'+u+'_ppp_mlppp'] = 0;
 /* SIZEOPTMORE-END */
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 			vis['_wan'+u+'_modem_pin'] = 0;
 			vis['_wan'+u+'_modem_dev'] = 0;
 			vis['_wan'+u+'_modem_init'] = 0;
@@ -843,6 +948,9 @@ function verifyFields(focused, quiet) {
 			vis['_wan'+u+'_modem_speed'] = 0;
 			vis['_wan'+u+'_modem_band'] = 0;
 			vis['_wan'+u+'_modem_roam'] = 0;
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 		break;
 		case 'pptp':
@@ -853,6 +961,9 @@ function verifyFields(focused, quiet) {
 			vis['_wan'+u+'_netmask'] = (!E('_f_wan'+u+'_pptp_dhcp').checked);
 			vis['_wan'+u+'_modem_ipaddr'] = 0;
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 			vis['_wan'+u+'_modem_pin'] = 0;
 			vis['_wan'+u+'_modem_dev'] = 0;
 			vis['_wan'+u+'_modem_init'] = 0;
@@ -860,6 +971,9 @@ function verifyFields(focused, quiet) {
 			vis['_wan'+u+'_modem_speed'] = 0;
 			vis['_wan'+u+'_modem_band'] = 0;
 			vis['_wan'+u+'_modem_roam'] = 0;
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 		break;
 		case 'l2tp':
@@ -870,6 +984,9 @@ function verifyFields(focused, quiet) {
 			vis['_wan'+u+'_netmask'] = (!E('_f_wan'+u+'_pptp_dhcp').checked);
 			vis['_wan'+u+'_modem_ipaddr'] = 0;
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 			vis['_wan'+u+'_modem_pin'] = 0;
 			vis['_wan'+u+'_modem_dev'] = 0;
 			vis['_wan'+u+'_modem_init'] = 0;
@@ -877,11 +994,20 @@ function verifyFields(focused, quiet) {
 			vis['_wan'+u+'_modem_speed'] = 0;
 			vis['_wan'+u+'_modem_band'] = 0;
 			vis['_wan'+u+'_modem_roam'] = 0;
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 		break;
 		}
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 		vis['_wan'+u+'_modem_band'] = (E('_wan'+u+'_modem_speed').value == '03') && vis['_wan'+u+'_modem_speed'] && (nvram['wan'+u+'_modem_type'] != "qmi_wwan");
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 		if (E('_mwan_cktime').value == 0) {
 			vis['_wan'+u+'_ckmtd'] = 0;
@@ -938,6 +1064,11 @@ function verifyFields(focused, quiet) {
 			u = wl_unit(uidx);
 			wmode = E('_f_wl'+u+'_mode').value;
 
+			var ssidScanButton = E('_f_wl' + u + '_ssidscan');
+			if (ssidScanButton) ssidScanButton.style.display = (wmode === 'ap') ? 'none' : '';
+			var macScanButton = E('_f_wl' + u + '_macscan');
+			if (macScanButton) macScanButton.style.display = (wmode !== 'ap' && wmode !== 'apwds' && wmode !== 'wds') ? '' : 'none';
+
 			if (!E('_f_wl'+u+'_radio').checked) { /* WL is disabled */
 				for (a in wl_vis[uidx]) {
 					wl_vis[uidx][a] = 2;
@@ -974,6 +1105,12 @@ function verifyFields(focused, quiet) {
 			switch (wmode) {
 			case 'apwds':
 			case 'wds':
+/* RTNPLUS-BEGIN */
+				/* ensure WDS fields render for all radios in WDS modes */
+				wl_vis[uidx]._f_wl_lazywds = (!E('_f_wl'+u+'_radio').checked) ? 2 : 1;
+				wl_vis[uidx]._f_wl_wds_0 = (!E('_f_wl'+u+'_radio').checked) ? 2 : 1;
+				wl_vis[uidx]._f_wl_clap_hwaddr = 0;
+/* RTNPLUS-END */
 				break;
 			case 'wet':
 /* BCMWL6-BEGIN */
@@ -981,8 +1118,10 @@ function verifyFields(focused, quiet) {
 /* BCMWL6-END */
 			case 'sta':
 				wl_vis[uidx]._f_wl_bcast = 0;
-				/* wl_vis[uidx]._wl_channel = 0; */
-				/* wl_vis[uidx]._wl_nbw_cap = 0; */
+				wl_vis[uidx]._wl_net_mode = 0;
+				wl_vis[uidx]._wl_channel = 0;
+				wl_vis[uidx]._wl_nbw_cap = 0;
+				wl_vis[uidx]._f_wl_nctrlsb = 0;
 				vis['_wan_modem_ipaddr'] = 0;
 /* RTNPLUS-BEGIN */
 				if (!E('_f_wl'+u+'_radio').checked) /* WL is disabled */
@@ -1035,7 +1174,7 @@ function verifyFields(focused, quiet) {
 			}
 
 			if ((E('_f_wl'+u+'_lazywds').value == 1) && (wl_vis[uidx]._f_wl_wds_0 == 1))
-				wl_vis[uidx]._f_wl_wds_0 = 2;
+				wl_vis[uidx]._f_wl_wds_0 = 0;
 
 			if (wl_vis[uidx]._wl_nbw_cap != 0) {
 				switch (E('_wl'+u+'_net_mode').value) {
@@ -1089,6 +1228,17 @@ REMOVE-END */
 			}
 
 			wl_vis[uidx]._f_wl_scan = wl_vis[uidx]._wl_channel;
+			var isClientMode = ((wmode == 'wet')
+/* BCMWL6-BEGIN */
+				|| (wmode == 'psta')
+/* BCMWL6-END */
+				|| (wmode == 'sta'));
+			var pskRandom1 = E('_f_wl'+u+'_psk_random1');
+			if (pskRandom1)
+				pskRandom1.style.display = isClientMode ? 'none' : '';
+			var pskRandom2 = E('_f_wl'+u+'_psk_random2');
+			if (pskRandom2)
+				pskRandom2.style.display = isClientMode ? 'none' : '';
 			wl_vis[uidx]._f_wl_psk_random1 = wl_vis[uidx]._wl_wpa_psk;
 			wl_vis[uidx]._f_wl_psk_random2 = wl_vis[uidx]._wl_radius_key;
 			wl_vis[uidx]._wl_radius_port = wl_vis[uidx]._wl_radius_ipaddr;
@@ -1096,6 +1246,34 @@ REMOVE-END */
 
 			for (i = 1; i < 10; ++i)
 				wl_vis[uidx]['_f_wl_wds_'+i] = wl_vis[uidx]._f_wl_wds_0;
+
+			var broadcastEnabled = E('_f_wl'+u+'_bcast').checked;
+			if (!broadcastEnabled)
+				wl_vis[uidx]._wl_ssid = 2;
+			else if (wl_vis[uidx]._wl_ssid != 2)
+				wl_vis[uidx]._wl_ssid = 1;
+			var ssidElement = document.getElementsByName('wl'+u+'_ssid')[0];
+			if (ssidElement && !broadcastEnabled && ssidElement.tagName.toLowerCase() == 'select') {
+				ssidElement.outerHTML = '<input type="text" name="'+ssidElement.name+'" id="_wl'+u+'_ssid">';
+				ssidElement = document.getElementsByName('wl'+u+'_ssid')[0];
+			}
+			if (ssidElement) {
+				if (!broadcastEnabled) {
+					if (typeof ssidHiddenStore[u] === 'undefined')
+						ssidHiddenStore[u] = ssidElement.value;
+					ssidElement.value = ' < hidden >';
+					ssidElement.disabled = true;
+				}
+				else {
+					if (typeof ssidHiddenStore[u] !== 'undefined') {
+						ssidElement.value = ssidHiddenStore[u];
+						delete ssidHiddenStore[u];
+					}
+					ssidElement.disabled = false;
+				}
+			}
+			if (ssidScanButton)
+				ssidScanButton.disabled = !broadcastEnabled;
 		}
 	} /* for each wl_iface */
 
@@ -1141,7 +1319,11 @@ REMOVE-END */
 				if (a.substr(0, 6) == '_f_wl_')
 					i = 5;
 
-				b = E(a.substr(0, i) + wl_unit(uidx) + a.substr(i, a.length));
+					b = E(a.substr(0, i) + wl_unit(uidx) + a.substr(i, a.length));
+					if (!b) {
+						console.error('Element not found:', a.substr(0, i) + wl_unit(uidx) + a.substr(i, a.length));
+						return;
+					}
 				c = wl_vis[uidx][a];
 				b.disabled = (c != 1);
 				PR(b).style.display = (c ? 'table-row' : 'none');
@@ -1190,9 +1372,9 @@ REMOVE-END */
 			ferror.clear(b);
 			if ((wmode == 'sta') || (wmode == 'wet')
 /* BCMWL6-BEGIN */
-			    || (wmode == 'psta')
+				|| (wmode == 'psta')
 /* BCMWL6-END */
-			   ) {
+			) {
 				++wlclnt;
 				if (wlclnt > 1) {
 					ferror.set(b, 'Only one wireless interface can be configured in client mode.', quiet || !ok);
@@ -1225,7 +1407,7 @@ REMOVE-END */
 
 			/* wl channel */
 			if (((wmode == 'wds') || (wmode == 'apwds')) && (wl_vis[uidx]._wl_channel == 1) && (E('_wl'+u+'_channel').value == '0')) {
-				ferror.set('_wl'+u+'_channel', 'Fixed wireless channel required in WDS mode.', quiet || !ok);
+				ferror.set('_wl'+u+'_channel', 'All the WDS peers must share the same static wireless channel.', quiet || !ok);
 				ok = 0;
 			}
 			else
@@ -1249,7 +1431,13 @@ REMOVE-END */
 		if ((vis['_wan'+u+'_gateway']) && (!v_ip('_wan'+u+'_gateway', quiet))) ok = 0;
 		if ((vis['_wan'+u+'_modem_ipaddr']) && (!v_ip('_wan'+u+'_modem_ipaddr', quiet))) ok = 0;
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 		if ((vis['_wan'+u+'_hilink_ip']) && (!v_ip('_wan'+u+'_hilink_ip', quiet))) ok = 0;
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 		if ((vis['_wan'+u+'_ppp_demand_dnsip']) && (!v_ip('_wan'+u+'_ppp_demand_dnsip', quiet))) ok = 0;
 		/* WANx netmask */
@@ -1281,9 +1469,9 @@ REMOVE-END */
 
 			if ((wmode == 'sta') || (wmode == 'wet')
 /* BCMWL6-BEGIN */
-			    || (wmode == 'psta')
+				|| (wmode == 'psta')
 /* BCMWL6-END */
-			   ) {
+			) {
 				if (a.value.length > 16) {
 					if (!v_mac(a, quiet))
 						ok = 0;
@@ -1323,7 +1511,7 @@ REMOVE-END */
 			}
 
 			/* length */
-			a = [['_ssid', 1], ['_radius_key', 1]];
+			a = [['_ssid', 0], ['_radius_key', 1]];
 			for (i = a.length - 1; i >= 0; --i) {
 				v = a[i];
 				if ((wl_vis[uidx]['_wl'+v[0]]) && (!v_length('_wl'+u+v[0], quiet || !ok, v[1], E('_wl'+u+v[0]).maxlength))) ok = 0;
@@ -1458,6 +1646,9 @@ REMOVE-END */
 	}
 
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 	for (uidx = 1; uidx <= curr_mwan_num; ++uidx) {
 		u = (uidx > 1) ? uidx : '';
 		var lte3g = E('_wan'+u+'_proto').value;
@@ -1470,6 +1661,9 @@ REMOVE-END */
 			}
 		}
 	}
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 
 	return ok;
@@ -1499,13 +1693,14 @@ function save() {
 	var a, b, c, d, e;
 	var i, j;
 	var u, uidx, wan_uidx, wmode, sm2, wradio;
-	var curr_mwan_num = E('_mwan_num').value;
+	var curr_mwan_num = parseInt(E('_mwan_num').value, 10);
 	var s = '';
 
 	if (!verifyFields(null, 0))
 		return;
 
 	var fom = E('t_fom');
+	fom._reboot.value = 0;
 
 /* RTNPLUS-BEGIN */
 	/* save MAC addr for wl client modes (sta/psta/wet) - try to connect to this AP (default "empty" / not needed) */
@@ -1516,9 +1711,9 @@ function save() {
 
 			if ((wmode == 'sta') || (wmode == 'wet')
 /* BCMWL6-BEGIN */
-			    || (wmode == 'psta')
+				|| (wmode == 'psta')
 /* BCMWL6-END */
-			   ) {
+				) {
 				E('_wl'+u+'_clap_hwaddr').value = E('_f_wl'+u+'_clap_hwaddr').value;
 			}
 			else
@@ -1543,9 +1738,9 @@ function save() {
 
 			if ((wmode == 'wet')
 /* BCMWL6-BEGIN */
-			    || (wmode == 'psta')
+				|| (wmode == 'psta')
 /* BCMWL6-END */
-			   ) {
+				) {
 				for (wan_uidx = 1; wan_uidx <= MAXWAN_NUM; ++wan_uidx) {
 					d = (wan_uidx > 1) ? wan_uidx : '';
 					E('_wan'+d+'_proto').disabled = 0;
@@ -1723,7 +1918,7 @@ function save() {
 		fom['dhcpd'+j+'_endip'].value = (d[i][4] != '0') ? d[i][6] : '';
 
 /* REMOVE-BEGIN
-alert('lan'+j+'_ifname=' + fom['lan'+j+'_ifname'].value + '\n' +
+	alert('lan'+j+'_ifname=' + fom['lan'+j+'_ifname'].value + '\n' +
 	'lan'+j+'_stp=' + fom['lan'+j+'_stp'].value + '\n' +
 	'lan'+j+'_ipaddr=' + fom['lan'+j+'_ipaddr'].value + '\n' +
 	'lan'+j+'_netmask=' + fom['lan'+j+'_netmask'].value + '\n' +
@@ -1756,7 +1951,13 @@ REMOVE-END */
 		fom['wan'+u+'_ppp_mlppp'].value = fom['f_wan'+u+'_ppp_mlppp'].checked ? 1 : 0;
 /* SIZEOPTMORE-END */
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 		fom['wan'+u+'_status_script'].value = fom['f_wan'+u+'_status_script'].checked ? 1 : 0;
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 		fom['wan'+u+'_ck_pause'].value = fom['f_wan'+u+'_ck_pause'].checked ? 1 : 0;
 
@@ -1854,14 +2055,44 @@ function init() {
 			refreshNetModes(uidx);
 			refreshChannels(uidx);
 			refreshBandWidth(uidx);
+			var u = wl_unit(uidx);
+			var wmode = E('_f_wl'+u+'_mode').value;
+			var ssidScanButton = E('_f_wl' + u + '_ssidscan');
+			if (ssidScanButton) ssidScanButton.style.display = (wmode === 'ap') ? 'none' : '';
+			var macScanButton = E('_f_wl' + u + '_macscan');
+			if (macScanButton) macScanButton.style.display = (wmode !== 'ap' && wmode !== 'apwds' && wmode !== 'wds') ? '' : 'none';
+			attachModeChangeHandler(E('_f_wl'+u+'_mode'));
 		}
+	}
+	for (var wan_uidx = 1; wan_uidx <= MAXWAN_NUM; ++wan_uidx) {
+		var u = (wan_uidx > 1) ? wan_uidx : '';
+		attachModeChangeHandler(E('_wan'+u+'_sta'));
 	}
 	refreshWanSection();
 	eventHandler();
 }
+
+function attachModeChangeHandler(elem) {
+	if (!elem) return;
+	var handler = function() {
+		verifyFields(elem, 1);
+	};
+	if (elem.addEventListener)
+		elem.addEventListener('change', handler, false);
+	else if (elem.attachEvent)
+		elem.attachEvent('onchange', handler);
+	else {
+		var prev = elem.onchange;
+		elem.onchange = function(event) {
+			if (typeof prev === 'function') prev.call(this, event);
+			handler.call(this, event);
+		};
+	}
+}
 </script>
 
 </head>
+
 <body onload="init()">
 <form id="t_fom" method="post" action="tomato.cgi">
 <table id="container">
@@ -1922,7 +2153,7 @@ function init() {
 	createFieldTable('', [
 		{ title: 'Number of logical WANs', name: 'mwan_num', type: 'select', options: [['1','1 WAN'],['2','2 WAN']
 /* MULTIWAN-BEGIN */
-											   ,['3','3 WAN'],['4','4 WAN']
+				,['3','3 WAN'],['4','4 WAN']
 /* MULTIWAN-END */
 			], value: nvram.mwan_num, suffix: '&nbsp; <small>Please configure <a href="advanced-vlan.asp">VLAN<\/a> first<\/small>' },
 		{ title: 'Tune route cache', name: 'f_mwan_tune_gc', type: 'checkbox', suffix: '&nbsp; <small>for multiwan in load balancing mode<\/small>', value: (nvram['mwan_tune_gc'] == 1) },
@@ -1955,36 +2186,73 @@ function init() {
 /* SIZEOPTMORE-END */
 		W('<input type="hidden" name="wan'+u+'_dns">');
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
 		W('<input type="hidden" name="wan'+u+'_status_script">');
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
 		W('<input type="hidden" name="wan'+u+'_ck_pause">');
+
 		W('<input type="hidden" name="wan'+u+'_iface">');
 		W('<input type="hidden" name="wan'+u+'_ifname">');
 		W('<input type="hidden" name="wan'+u+'_hwaddr">');
 
 		W('<div class="section-title" id="wan'+u+'-title">WAN'+(uidx - 1)+' Settings<\/div>');
 		W('<div class="section" id="sesdiv_wan'+u+'">');
-		createFieldTable('', [
-			{ title: 'Type', name: 'wan'+u+'_proto', type: 'select', options: [['dhcp','DHCP'],['pppoe','PPPoE'],['static','Static'],['pptp','PPTP'],['l2tp','L2TP'],
+		var wanProtoOptions = [
+			['dhcp','DHCP'],
+			['pppoe','PPPoE'],
+			['static','Static'],
+			['pptp','PPTP'],
+			['l2tp','L2TP']
+		];
 /* USB-BEGIN */
-				['ppp3g','3G Modem'],
-				['lte','4G/LTE'],
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
+		wanProtoOptions.push(['ppp3g','3G Modem']);
+		wanProtoOptions.push(['lte','4G/LTE']);
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
-				['disabled','Disabled']],
+		wanProtoOptions.push(['disabled','Disabled']);
+
+		var wanFields = [
+			{ title: 'Type', name: 'wan'+u+'_proto', type: 'select', options: wanProtoOptions,
 				suffix: '&nbsp; <small id="_f_wan'+u+'_islan" style="display:none"><a href="advanced-vlan.asp">Bridge WAN ?<\/a><\/small>', value: nvram['wan'+u+'_proto'] },
-			{ title: 'Wireless Client Mode', name: 'wan'+u+'_sta', type: 'select', options: sta_list, value: nvram['wan'+u+'_sta'] },
+			{ title: 'Wireless Client Mode', name: 'wan'+u+'_sta', type: 'select', options: sta_list, value: nvram['wan'+u+'_sta'] }
+		];
 /* USB-BEGIN */
-			{ title: 'Modem device', name: 'wan'+u+'_modem_dev', type: 'select', options: [['/dev/ttyUSB0','/dev/ttyUSB0'],['/dev/ttyUSB1','/dev/ttyUSB1'],['/dev/ttyUSB2','/dev/ttyUSB2'],['/dev/ttyUSB3','/dev/ttyUSB3'],['/dev/ttyUSB4','/dev/ttyUSB4'],['/dev/ttyUSB5','/dev/ttyUSB5'],['/dev/ttyUSB6','/dev/ttyUSB6'],['/dev/ttyACM0','/dev/ttyACM0']], value: nvram['wan'+u+'_modem_dev'] },
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
+		wanFields.push({ title: 'Modem device', name: 'wan'+u+'_modem_dev', type: 'select', options: [['/dev/ttyUSB0','/dev/ttyUSB0'],['/dev/ttyUSB1','/dev/ttyUSB1'],['/dev/ttyUSB2','/dev/ttyUSB2'],['/dev/ttyUSB3','/dev/ttyUSB3'],['/dev/ttyUSB4','/dev/ttyUSB4'],['/dev/ttyUSB5','/dev/ttyUSB5'],['/dev/ttyUSB6','/dev/ttyUSB6'],['/dev/ttyACM0','/dev/ttyACM0']], value: nvram['wan'+u+'_modem_dev'] });
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
-			{ title: 'Load Balance Weight', name: 'wan'+u+'_weight', type: 'text', maxlen: 3, size: 8, value: nvram['wan'+u+'_weight'], suffix: '&nbsp; <small>Failover: 0; Load balancing: 1 - 256<\/small>' },
+		wanFields.push({ title: 'Load Balance Weight', name: 'wan'+u+'_weight', type: 'text', maxlen: 3, size: 8, value: nvram['wan'+u+'_weight'], suffix: '&nbsp; <small>Failover: 0; Load balancing: 1 - 256<\/small>' });
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
+		wanFields.push(
 			{ title: 'PIN Code', name: 'wan'+u+'_modem_pin', type: 'text', maxlen: 6, size: 8, value: nvram['wan'+u+'_modem_pin'], suffix: '&nbsp; <small>advised to turn off PIN Code<\/small>' },
 			{ title: 'Modem init string', name: 'wan'+u+'_modem_init', type: 'text', maxlen: 25, size: 32, value: nvram['wan'+u+'_modem_init'] },
 			{ title: 'APN', name: 'wan'+u+'_modem_apn', type: 'text', maxlen: 25, size: 32, suffix: '&nbsp; <small>if empty, AT+CGDCONT will not be sent<\/small>', value: nvram['wan'+u+'_modem_apn'] },
 			{ title: 'Network Type', name: 'wan'+u+'_modem_speed', type: 'select', options: [['00','Auto'],['030201','4G/3G/2G'],['0302','4G/3G only'],['03','4G only'],['02','3G only']], value: nvram['wan'+u+'_modem_speed'], suffix: '&nbsp; <small>works only with non-Hilink modems<\/small>' },
 			{ title: 'Roaming', name: 'wan'+u+'_modem_roam', type: 'select', options: [['2','No change*'],['1','Supported'],['0','Disabled'],['3','Roam only']], value: nvram['wan'+u+'_modem_roam'], suffix: '&nbsp; <small>*default; works only with non-Hilink modems<\/small>' },
-			{ title: 'LTE Band', name: 'wan'+u+'_modem_band', type: 'select', options: [['7FFFFFFFFFFFFFFF','All supported*'],['80000','B20 (800 MHz)'],['80','B8 (900 MHz)'],['4','B3 (1800 MHz)'],['1','B1 (2100 MHz)'],['40','B7 (2600 MHz)']], value: nvram['wan'+u+'_modem_band'], suffix: '&nbsp; <small>*default; tested only on non-Hilink Huawei modems<\/small>' },
+			{ title: 'LTE Band', name: 'wan'+u+'_modem_band', type: 'select', options: [['7FFFFFFFFFFFFFFF','All supported*'],['80000','B20 (800 MHz)'],['80','B8 (900 MHz)'],['4','B3 (1800 MHz)'],['1','B1 (2100 MHz)'],['40','B7 (2600 MHz)']], value: nvram['wan'+u+'_modem_band'], suffix: '&nbsp; <small>*default; tested only on non-Hilink Huawei modems<\/small>' }
+		);
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
+		wanFields.push(
 			{ title: 'Username', name: 'wan'+u+'_ppp_username', type: 'text', maxlen: 60, size: 64, value: nvram['wan'+u+'_ppp_username'] },
 			{ title: 'Password', name: 'wan'+u+'_ppp_passwd', type: 'password', maxlen: 60, size: 64, peekaboo: 1, value: nvram['wan'+u+'_ppp_passwd'] },
 			{ title: 'Service Name', name: 'wan'+u+'_ppp_service', type: 'text', maxlen: 50, size: 64, value: nvram['wan'+u+'_ppp_service'] },
@@ -1997,18 +2265,12 @@ function init() {
 			{ title: 'DNS Server', name: 'wan'+u+'_dns_auto', type: 'select', options: [['1','Auto'],['0','Manual']], suffix: '&nbsp; <small id="dns'+u+'_faq">inactive when using dncrypt-proxy/Stubby with No-Resolv option<\/small>', value: nvram['wan'+u+'_dns_auto']},
 			{ title: 'DNS 1', indent: 2, name: 'f_wan'+u+'_dns_1', type: 'text', maxlen: 21, size: 17, value: dns[0] || '0.0.0.0' },
 			{ title: 'DNS 2', indent: 2, name: 'f_wan'+u+'_dns_2', type: 'text', maxlen: 21, size: 17, value: dns[1] || '0.0.0.0' },
-			{ title: 'Connect Mode', name: 'wan'+u+'_ppp_demand', type: 'select', options: [['1','Connect On Demand'],['0','Keep Alive']],
-				value: nvram['wan'+u+'_ppp_demand'] },
-			{ title: 'IP to trigger Connect', indent: 2, name: 'wan'+u+'_ppp_demand_dnsip', type: 'text', maxlen: 15, size: 17, suffix: '&nbsp; <small>default: 198.51.100.1<\/small>',
-				value: nvram['wan'+u+'_ppp_demand_dnsip'] },
-			{ title: 'Max Idle Time', indent: 2, name: 'wan'+u+'_ppp_idletime', type: 'text', maxlen: 5, size: 7, suffix: '&nbsp; <small>minutes<\/small>',
-				value: nvram['wan'+u+'_ppp_idletime'] },
-			{ title: 'Redial Interval', indent: 2, name: 'wan'+u+'_ppp_redialperiod', type: 'text', maxlen: 5, size: 7, suffix: '&nbsp; <small>seconds<\/small>',
-				value: nvram['wan'+u+'_ppp_redialperiod'] },
-			{ title: 'LCP Echo Interval', indent: 2, name: 'wan'+u+'_pppoe_lei', type: 'text', maxlen: 5, size: 7, suffix: '&nbsp; <small>seconds; range: 1 - 60, default: 10<\/small>',
-				value: nvram['wan'+u+'_pppoe_lei'] },
-			{ title: 'LCP Echo Link fail limit', indent: 2, name: 'wan'+u+'_pppoe_lef', type: 'text', maxlen: 5, size: 7, suffix: '&nbsp; <small>range: 1 - 10, default: 5<\/small>',
-				value: nvram['wan'+u+'_pppoe_lef'] },
+			{ title: 'Connect Mode', name: 'wan'+u+'_ppp_demand', type: 'select', options: [['1','Connect On Demand'],['0','Keep Alive']], value: nvram['wan'+u+'_ppp_demand'] },
+			{ title: 'IP to trigger Connect', indent: 2, name: 'wan'+u+'_ppp_demand_dnsip', type: 'text', maxlen: 15, size: 17, suffix: '&nbsp; <small>default: 198.51.100.1<\/small>', value: nvram['wan'+u+'_ppp_demand_dnsip'] },
+			{ title: 'Max Idle Time', indent: 2, name: 'wan'+u+'_ppp_idletime', type: 'text', maxlen: 5, size: 7, suffix: '&nbsp; <small>minutes<\/small>', value: nvram['wan'+u+'_ppp_idletime'] },
+			{ title: 'Redial Interval', indent: 2, name: 'wan'+u+'_ppp_redialperiod', type: 'text', maxlen: 5, size: 7, suffix: '&nbsp; <small>seconds<\/small>', value: nvram['wan'+u+'_ppp_redialperiod'] },
+			{ title: 'LCP Echo Interval', indent: 2, name: 'wan'+u+'_pppoe_lei', type: 'text', maxlen: 5, size: 7, suffix: '&nbsp; <small>seconds; range: 1 - 60, default: 10<\/small>', value: nvram['wan'+u+'_pppoe_lei'] },
+			{ title: 'LCP Echo Link fail limit', indent: 2, name: 'wan'+u+'_pppoe_lef', type: 'text', maxlen: 5, size: 7, suffix: '&nbsp; <small>range: 1 - 10, default: 5<\/small>', value: nvram['wan'+u+'_pppoe_lef'] },
 			{ title: 'MTU', multi: [
 				{ name: 'wan'+u+'_mtu_enable', type: 'select', options: [['0', 'Default'],['1','Manual']], value: nvram['wan'+u+'_mtu_enable'] },
 				{ name: 'f_wan'+u+'_mtu', type: 'text', maxlen: 4, size: 6, value: nvram['wan'+u+'_mtu'] } ] },
@@ -2016,18 +2278,29 @@ function init() {
 /* SIZEOPTMORE-BEGIN */
 			{ title: 'Single Line MLPPP', name: 'f_wan'+u+'_ppp_mlppp', type: 'checkbox', value: (nvram['wan'+u+'_ppp_mlppp'] == 1) },
 /* SIZEOPTMORE-END */
-			{ title: 'Route Modem IP', name: 'wan'+u+'_modem_ipaddr', type: 'text', maxlen: 15, size: 17, suffix: '&nbsp; <small>must be in different subnet to router, 0.0.0.0 to disable<\/small>', value: nvram['wan'+u+'_modem_ipaddr'] },
+			{ title: 'Route Modem IP', name: 'wan'+u+'_modem_ipaddr', type: 'text', maxlen: 15, size: 17, suffix: '&nbsp; <small>must be in different subnet to router, 0.0.0.0 to disable<\/small>', value: nvram['wan'+u+'_modem_ipaddr'] }
+		);
 /* USB-BEGIN */
+/* REMOVE-BEGIN */
+if (hasUsbSupport) {
+/* REMOVE-END */
+		wanFields.push(
 			{ title: 'Query HiLink Modem IP', name: 'wan'+u+'_hilink_ip', type: 'text', maxlen: 15, size: 17, suffix: '&nbsp; <small>show status of reachable hilink modem, 0.0.0.0 to disable<\/small>', value: nvram['wan'+u+'_hilink_ip'] },
-			{ title: 'Call Custom Status Script', name: 'f_wan'+u+'_status_script', type: 'checkbox', suffix: '&nbsp; <small>Call /www/user/cgi-bin/wan'+u+'_status.sh in the home page. Must output HTML<\/small>', value: (nvram['wan'+u+'_status_script'] == 1) },
+			{ title: 'Call Custom Status Script', name: 'f_wan'+u+'_status_script', type: 'checkbox', suffix: '&nbsp; <small>Call /www/user/cgi-bin/wan'+u+'_status.sh in the home page. Must output HTML<\/small>', value: (nvram['wan'+u+'_status_script'] == 1) }
+		);
+/* REMOVE-BEGIN */
+}
+/* REMOVE-END */
 /* USB-END */
+		wanFields.push(
 			{ title: 'Disable Watchdog', name: 'f_wan'+u+'_ck_pause', type: 'checkbox', suffix: '&nbsp; <small>only for this WAN<\/small>', value: (nvram['wan'+u+'_ck_pause'] == 1) },
 			{ title: 'Watchdog Mode', name: 'wan'+u+'_ckmtd', type: 'select', options: [['1','Ping'],['2','Traceroute*']
 /* BBT-BEGIN */
 				,['3','Curl']
 /* BBT-END */
 				], value: nvram['wan'+u+'_ckmtd'], suffix: '&nbsp; <small>*default; use the other method only when Traceroute is not working correctly<\/small>' }
-		]);
+		);
+		createFieldTable('', wanFields);
 		W('<\/div>');
 	}
 </script>
@@ -2070,7 +2343,7 @@ function init() {
 <div class="section">
 <script>
 	createFieldTable('', [
-		{ title: 'Enable', name: 'f_smart_connect_x', type: 'checkbox', value: (nvram.smart_connect_x == 1), suffix: ' <small>(Wireless settings will be synced to module one after saving to nvram!)<\/small>' }
+		{ title: 'Enable', name: 'f_smart_connect_x', type: 'checkbox', value: (nvram.smart_connect_x == 1), suffix: ' <small>Wireless settings from wl0 will sync to wl1 avter the Save<\/small>' }
 	]);
 </script>
 </div>
@@ -2112,28 +2385,31 @@ function init() {
 			W('<div class="section">');
 
 			var f = [
-				{ title: 'Enable Wireless', name: 'f_wl'+u+'_radio', type: 'checkbox',
+				{ title: 'Enable', name: 'f_wl'+u+'_radio', type: 'checkbox',
 					value: (nvram['wl'+u+'_radio'] == '1') && (nvram['wl'+u+'_net_mode'] != 'disabled') },
 				{ title: 'MAC Address', text: '<a href="advanced-mac.asp">'+nvram['wl'+u+'_hwaddr']+'<\/a>' },
 				{ title: 'Wireless Mode', name: 'f_wl'+u+'_mode', type: 'select',
 					options: [['ap','Access Point'],['apwds','Access Point + WDS'],['sta','Wireless Client'],['wet','Wireless Ethernet Bridge'],['wds','WDS']
 /* BCMWL6-BEGIN */
-						  ,['psta','Media Bridge']
+						,['psta','Media Bridge']
 /* BCMWL6-END */
-						 ],
+						],
 					value: ((nvram['wl'+u+'_mode'] == 'ap') && (nvram['wl'+u+'_wds_enable'] == '1')) ? 'apwds' : nvram['wl'+u+'_mode'] },
 				{ title: 'Radio Band', name: 'f_wl'+u+'_nband', type: 'select', options: bands[uidx],
 					value: nvram['wl'+u+'_nband'] || '0' == '0' ? bands[uidx][0][0] : nvram['wl'+u+'_nband'] },
 				{ title: 'Wireless Network Mode', name: 'wl'+u+'_net_mode', type: 'select',
 					value: (nvram['wl'+u+'_net_mode'] == 'disabled') ? 'mixed' : nvram['wl'+u+'_net_mode'],
 					options: [], prefix: '<span id="__wl'+u+'_net_mode">', suffix: '<\/span>' },
-				{ title: 'SSID', name: 'wl'+u+'_ssid', type: 'text', maxlen: 32, size: 34, value: nvram['wl'+u+'_ssid'] },
-				{ title: 'Broadcast', indent: 2, name: 'f_wl'+u+'_bcast', type: 'checkbox', value: (nvram['wl'+u+'_closed'] == '0') },
-				{ title: 'Channel', name: 'wl'+u+'_channel', type: 'select', options: ghz[uidx], prefix: '<span id="__wl'+u+'_channel">', suffix: '<\/span> <input type="button" id="_f_wl'+u+'_scan" value="Scan" onclick="scanButton('+u+')"> <img src="spin.svg" alt="" id="spin'+u+'">',
+				{ title: 'Broadcast SSID', name: 'f_wl'+u+'_bcast', type: 'checkbox', value: (nvram['wl'+u+'_closed'] == '0') },
+				{ title: 'SSID', indent: 2, name: 'wl'+u+'_ssid', type: 'text', maxlen: 32, size: 34, value: nvram['wl'+u+'_ssid'], placeholder: ' < case sensitive >', prefix: '<span id="__wl'+u+'_ssid">', suffix: '<\/span> <input type="button" id="_f_wl'+u+'_ssidscan" value="Scan" onclick="scanButton('+u+', \'ssid\')"> <img src="spin.svg" alt="" id="spinSsid'+u+'" style="display:none;"> <select id="ssidList'+u+'" style="display:none" onchange="selectSsid(this, '+u+')"><\/select>', onchange: 'clearBssidIfPresent('+u+')' },
+/* RTNPLUS-BEGIN */
+				{ title: 'BSSID lock', indent: 2, name: 'f_wl'+u+'_clap_hwaddr', type: 'text', placeholder: ' < optional >', maxlen: 17, size: 16, value: nvram['wl'+u+'_clap_hwaddr'], suffix: ' <input type="button" id="_f_wl'+u+'_macscan" value="Scan" title="Predefined SSID only" onclick="scanBSSID\('+u+')" style="display:none"> <img src="spin.svg" alt="" id="spinMac'+u+'" style="display:none;"> <small> Defined SSID only<\/small>' },
+/* RTNPLUS-END */					
+				{ title: 'Channel', indent: 2, name: 'wl'+u+'_channel', type: 'select', options: ghz[uidx], prefix: '<span id="__wl'+u+'_channel">', suffix: '<\/span> <input type="button" id="_f_wl'+u+'_scan" value="Scan" onclick="scanButton('+u+')"> <img src="spin.svg" alt="" id="spin'+u+'">',
 					value: nvram['wl'+u+'_channel'] },
-				{ title: 'Channel Width', name: 'wl'+u+'_nbw_cap', type: 'select', options: [],
+				{ title: 'Channel Width', indent: 2, name: 'wl'+u+'_nbw_cap', type: 'select', options: [],
 					value: nvram['wl'+u+'_nbw_cap'], prefix: '<span id="__wl'+u+'_nbw_cap">', suffix: '<\/span>' },
-				{ title: 'Control Sideband', name: 'f_wl'+u+'_nctrlsb', type: 'select', options: [['lower','Lower'],['upper','Upper']],
+				{ title: 'Control Sideband', indent: 2, name: 'f_wl'+u+'_nctrlsb', type: 'select', options: [['lower','Lower'],['upper','Upper']],
 					value: nvram['wl'+u+'_nctrlsb'] == 'none' ? 'lower' : nvram['wl'+u+'_nctrlsb'] },
 				null,
 				{ title: 'Security', name: 'wl'+u+'_security_mode', type: 'select',
@@ -2141,19 +2417,22 @@ function init() {
 					value: nvram['wl'+u+'_security_mode'] },
 				{ title: 'Encryption', indent: 2, name: 'wl'+u+'_crypto', type: 'select',
 					options: [['tkip','TKIP'],['aes','AES'],['tkip+aes','TKIP / AES']], value: nvram['wl'+u+'_crypto'] },
-				{ title: 'Shared Key', indent: 2, name: 'wl'+u+'_wpa_psk', type: 'password', maxlen: 64, size: 66, peekaboo: 1,
-					suffix: ' <input type="button" id="_f_wl'+u+'_psk_random1" value="Random" onclick="random_psk(\'_wl'+u+'_wpa_psk\')">',
+				{ title: 'Shared Key', indent: 2, name: 'wl'+u+'_wpa_psk', type: 'password', placeholder: ' < case sensitive >', maxlen: 63, size: 34, peekaboo: 1,
+					suffix: ' <select id="_f_wl'+u+'_psk_random1" onchange="random_psk(\'_wl'+u+'_wpa_psk\', \'_f_wl'+u+'_psk_random1\')" style="width:auto"><option value="default" style="color:grey" selected>Random</option><option value="clear">Clear</option><option value="8">8 chars</option><option value="10">10 chars</option><option value="12">12 chars</option><option value="14">14 chars</option><option value="16">16 chars</option><option value="18">18 chars</option><option value="20">20 chars</option><option value="24">24 chars</option><option value="32">32 chars</option><option value="48">48 chars</option><option value="63">63 chars</option></select>',
 					value: nvram['wl'+u+'_wpa_psk'] },
-				{ title: 'Shared Key', indent: 2, name: 'wl'+u+'_radius_key', type: 'password', maxlen: 80, size: 32, peekaboo: 1,
-					suffix: ' <input type="button" id="_f_wl'+u+'_psk_random2" value="Random" onclick="random_psk(\'_wl'+u+'_radius_key\')">',
+				{ title: 'Shared Key', indent: 2, name: 'wl'+u+'_radius_key', type: 'password', maxlen: 80, size: 34, peekaboo: 1,
+					suffix: ' <select id="_f_wl'+u+'_psk_random2" onchange="random_psk(\'_wl'+u+'_radius_key\', \'_f_wl'+u+'_psk_random2\')" style="width:auto"><option value="default" style="color:grey" selected>Random</option><option value="clear">Clear</option><option value="8">8 chars</option><option value="10">10 chars</option><option value="12">12 chars</option><option value="16">16 chars</option><option value="24">24 chars</option><option value="32">32 chars</option><option value="48">48 chars</option><option value="63">63 chars</option></select>',
 					value: nvram['wl'+u+'_radius_key'] },
-/* RTNPLUS-NO-BEGIN */
-				{ title: 'Group Key Renewal', indent: 2, name: 'wl'+u+'_wpa_gtk_rekey', type: 'text', maxlen: 4, size: 6, suffix: '&nbsp; <small>seconds<\/small>',
-/* RTNPLUS-NO-END */
+				{ title: 'Group Key Renewal', indent: 2, name: 'wl'+u+'_wpa_gtk_rekey',  type: 'text',
 /* RTNPLUS-BEGIN */
-				{ title: 'Group Key Renewal', indent: 2, name: 'wl'+u+'_wpa_gtk_rekey', type: 'text', maxlen: 7, size: 9, suffix: '&nbsp; <small>seconds<\/small>',
+					maxlen: 7,
+					size: 9,
 /* RTNPLUS-END */
-					value: nvram['wl'+u+'_wpa_gtk_rekey'] },
+/* RTNPLUS-NO-BEGIN */
+					maxlen: 4,
+					size: 6,
+/* RTNPLUS-NO-END */
+					suffix: '&nbsp; <small>seconds<\/small>', value: nvram['wl'+u+'_wpa_gtk_rekey'] },
 				{ title: 'Radius Server', indent: 2, multi: [
 					{ name: 'wl'+u+'_radius_ipaddr', type: 'text', maxlen: 15, size: 17, value: nvram['wl'+u+'_radius_ipaddr'] },
 					{ name: 'wl'+u+'_radius_port', type: 'text', maxlen: 5, size: 7, prefix: ' : ', value: nvram['wl'+u+'_radius_port'] } ] },
@@ -2170,22 +2449,21 @@ function init() {
 						suffix: '<input type="radio" onchange="verifyFields(this,1)" onclick="verifyFields(this,1)" name="f_wl'+u+'_wepidx" id="_f_wl'+u+'_wepidx_'+i+'" value="'+i+'"'+((nvram['wl'+u+'_key'] == i) ? ' checked="checked">' : '>'),
 						value: nvram['wl'+u+'_key'+i] });
 			}
-/* RTNPLUS-BEGIN */
-			f.push(null, { title: 'AP MAC Address to connect', name: 'f_wl'+u+'_clap_hwaddr', type: 'text', maxlen: 17, size: 20, value: nvram['wl'+u+'_clap_hwaddr'], suffix: ' <small>(usually empty/not needed)<\/small>' } );
-/* RTNPLUS-END */
-			f.push(null, { title: 'WDS', name: 'f_wl'+u+'_lazywds', type: 'select', options: [['0','Link With...'],['1','Automatic']], value: nvram['wl'+u+'_lazywds'] } );
+			
+			f.push(null, { title: 'WDS peering policy', name: 'f_wl'+u+'_lazywds', type: 'select', options: [['0','Restricted'],['1','Open']], value: nvram['wl'+u+'_lazywds'], onchange: 'verifyFields(null,1)' } );
 
 			var wds = nvram['wl'+u+'_wds'].split(/\s+/);
-			for (i = 0; i < 10; i += 2) {
-				f.push(
-					{ title: (i ? '' : 'MAC Address'), indent: 2, multi: [
+				for (i = 0; i < 10; i += 2) {
+					f.push(
+						{ title: (i ? '' : 'Allowed BSSID peers'), indent: 2, multi: [
 						{ name: 'f_wl'+u+'_wds_'+i, type: 'text', maxlen: 17, size: 20, value: wds[i] || mac_null },
-						{ name: 'f_wl'+u+'_wds_'+(i + 1), type: 'text', maxlen: 17, size: 20, value: wds[i + 1] || mac_null } ] } );
-			}
-			createFieldTable('', f);
-			W('<\/div>');
-		}
+						{ custom: '<input type="button" id="_f_wl'+u+'_wdsscan_'+i+'" value="Scan" title="Predefined SSID only" onclick="scanBSSID\('+u+', \'_f_wl'+u+'_wds_'+i+'\', \'macListWds'+u+'_'+i+'\', \'spinWdsMac'+u+'_'+i+'\', \'_f_wl'+u+'_wdsscan_'+i+'\')"> <img src="spin.svg" alt="" id="spinWdsMac'+u+'_'+i+'" style="display:none;">'
+							+ '<input type="hidden" id="_f_wl'+u+'_wds_'+(i + 1)+'" name="f_wl'+u+'_wds_'+(i + 1)+'" value="'+(wds[i + 1] || mac_null)+'">' } ] } );
+				}
+					createFieldTable('', f);
+					W('<\/div>');
 	}
+}
 /* for each wlif */
 </script>
 

--- a/release/src-rt-6.x.4708/router/www/wireless.js
+++ b/release/src-rt-6.x.4708/router/www/wireless.js
@@ -1,3 +1,30 @@
+function getElementSize(el) {
+	if (!el) return { width: '', minWidth: '' };
+	var computed = window.getComputedStyle ? window.getComputedStyle(el) : el.style;
+	var width = (computed.width && computed.width !== 'auto') ? computed.width : (el.offsetWidth ? el.offsetWidth + 'px' : el.style.width || '');
+	var minWidth = (computed.minWidth && computed.minWidth !== 'auto') ? computed.minWidth : (el.style.minWidth || width);
+	if (!minWidth || minWidth === '0px') minWidth = width;
+	if (!width) width = el.style.width || 'auto';
+	if (!minWidth) minWidth = width;
+	return { width: width, minWidth: minWidth };
+}
+
+function storeElementSize(el) {
+	var size = getElementSize(el);
+	if (size.width) el.dataset.originalWidth = size.width;
+	if (size.minWidth) el.dataset.originalMinWidth = size.minWidth;
+	return size;
+}
+
+function applyElementSize(el, width, minWidth) {
+	var w = width || el.dataset.originalWidth;
+	var m = minWidth || el.dataset.originalMinWidth || w;
+	if (w) el.style.width = w;
+	if (m) el.style.minWidth = m;
+	if (w) el.dataset.originalWidth = w;
+	if (m) el.dataset.originalMinWidth = m;
+}
+
 function selectedBand(uidx) {
 	if (bands[uidx].length > 1) {
 		var u = wl_fface(uidx);
@@ -82,7 +109,7 @@ function refreshBandWidth(uidx) {
 
 function refreshChannels(uidx) {
 	if (refresher[uidx] != null) return;
-	if (u >= wl_ifaces.length) return;
+	if (uidx >= wl_ifaces.length) return;
 	var u = wl_unit(uidx);
 
 	refresher[uidx] = new XmlHttp();
@@ -225,31 +252,322 @@ function scan() {
 	xob.post('update.cgi', 'exec=wlscan&arg0='+unit);
 }
 
-function spin(x, unit) {
+function spin(x, unit, type) {
 	for (var u = 0; u < wl_ifaces.length; ++u) {
-		E('_f_wl'+wl_unit(u)+'_scan').disabled = x;
+		if (type === 'ssid') {
+			E('_f_wl'+wl_unit(u)+'_ssidscan').disabled = x;
+		} else {
+			E('_f_wl'+wl_unit(u)+'_scan').disabled = x;
+		}
 	}
-	var e = E('_f_wl'+unit+'_scan');
+	var e = type === 'ssid' ? E('_f_wl'+unit+'_ssidscan') : E('_f_wl'+unit+'_scan');
 
 	if (x)
 		e.value = 'Scan ' + (wscan.tries + 1);
 	else
 		e.value = 'Scan';
 
-	E('spin'+unit).style.display = (x ? 'inline' : 'none');
+	E(type === 'ssid' ? 'spinSsid'+unit : 'spin'+unit).style.display = (x ? 'inline' : 'none');
 }
 
-function scanButton(u) {
+function scanButton(u, type) {
 	if (xob) return;
 
 	wscan = {
 		unit: u,
 		seen: [],
 		inuse: [],
-		tries: 0
+		tries: 0,
+		scanned: false
 	};
 
-	scan();
+	if (type === 'ssid') {
+		scanSSID();
+	} else {
+		scan();
+	}
+}
+
+function scanSSID() {
+	var unit = wscan.unit;
+	var ssidInput = document.getElementsByName('wl' + unit + '_ssid')[0];
+	var spinElement = document.getElementById('spinSsid' + unit);
+
+	var size = storeElementSize(ssidInput);
+	var widthValue = size.width || 'auto';
+	var minWidthValue = size.minWidth || widthValue;
+	ssidInput.outerHTML = '<select name="wl' + unit + '_ssid" id="ssidList' + unit + '" style="width: ' + widthValue + '; min-width: ' + minWidthValue + ';" onchange="selectSsid(this, ' + unit + ')" data-original-width="' + widthValue + '" data-original-min-width="' + minWidthValue + '"><\/select>';
+	var list = document.getElementById('ssidList' + unit);
+	if (list) {
+		list.dataset.originalWidth = widthValue;
+		list.dataset.originalMinWidth = minWidthValue;
+		applyElementSize(list, widthValue, minWidthValue);
+	}
+
+	spinElement.style.display = 'inline';
+
+	xob = new XmlHttp();
+	xob.onCompleted = function(text, xml) {
+		try {
+			spinElement.style.display = 'none';
+			list.style.display = '';
+
+			var option = document.createElement('option');
+			option.value = '';
+			option.text = '❮❮ Scan result ❯❯';
+			option.disabled = true;
+			option.style.color = 'grey';
+			option.selected = true;
+			list.appendChild(option);
+
+			wlscandata = [];
+			eval(text);
+			var seenSSIDs = {};
+			wlscandata.forEach(function(data) {
+				var ssid = data[1];
+				var quality = data[5];
+				if (ssid.trim() !== '' && !seenSSIDs[ssid]) {
+					var option = document.createElement('option');
+					option.value = ssid;
+					option.text = ssid + ' 🛜 ' + quality + '%';
+					list.appendChild(option);
+					seenSSIDs[ssid] = true;
+				}
+			});
+
+			var typeManuallyOption = document.createElement('option');
+			typeManuallyOption.value = 'manual';
+			typeManuallyOption.text = '❯❯ Switch to manual input ❮❮';
+			list.appendChild(typeManuallyOption);
+
+			wscan.scanned = true;
+		} catch (x) {
+			console.error(x);
+		}
+		xob = null;
+		spin(0, unit, 'ssid');
+	};
+	xob.onError = function(x) {
+		alert('error: ' + x);
+		spinElement.style.display = 'none';
+		xob = null;
+		spin(0, unit, 'ssid');
+	};
+	spin(1, unit, 'ssid');
+	xob.post('update.cgi', 'exec=wlscan&arg0=' + unit);
+}
+
+function selectSsid(select, u) {
+	var ssidInput = document.createElement('input');
+	ssidInput.type = 'text';
+	ssidInput.name = 'wl' + u + '_ssid';
+	ssidInput.id = '_wl' + u + '_ssid';
+
+	var widthInfo = {
+		width: select.dataset.originalWidth || select.style.width,
+		minWidth: select.dataset.originalMinWidth || select.style.minWidth
+	};
+	applyElementSize(ssidInput, widthInfo.width, widthInfo.minWidth);
+	ssidInput.style.visibility = 'hidden';
+	var parent = select.parentNode;
+	parent.insertBefore(ssidInput, select);
+	parent.removeChild(select);
+	ssidInput.style.visibility = '';
+
+	if (select.value === 'manual') {
+		// already swapped above
+	} else {
+		ssidInput.value = select.options[select.selectedIndex].value.trim();
+	}
+	clearBssidIfPresent(u);
+	verifyFields(ssidInput, 1);
+}
+
+function scanBSSID(unit, targetId, listId, spinnerId, buttonId, filterMode) {
+	if (xob) return;
+
+	var applySsidFilter = (filterMode !== 0) && (filterMode !== '0');
+
+	var tid = targetId || ('_f_wl' + unit + '_clap_hwaddr');
+	var lid = listId || ('macList' + unit);
+	var sid = spinnerId || ('spinMac' + unit);
+	var bid = buttonId || ('_f_wl' + unit + '_macscan');
+
+	var macInput = E(tid) || document.getElementsByName('f_wl' + unit + '_clap_hwaddr')[0];
+	if (!macInput) return;
+
+	var spinElement = E(sid);
+	var scanButton = E(bid);
+	if (scanButton) scanButton.disabled = 1;
+	if (spinElement) spinElement.style.display = 'inline';
+
+	var size = storeElementSize(macInput);
+	var widthValue = size.width || 'auto';
+	var minWidthValue = size.minWidth || widthValue;
+	macInput.dataset.originalWidth = widthValue;
+	macInput.dataset.originalMinWidth = minWidthValue;
+	var styleW = 'width: ' + widthValue + '; min-width: ' + minWidthValue + ';';
+	macInput.outerHTML = "<select name=\"" + macInput.name + "\" id=\"" + lid + "\" style=\"" + styleW + "\" data-original-width=\"" + widthValue + "\" data-original-min-width=\"" + minWidthValue + "\" onchange=\"selectBSSID(this, " + unit + ", '" + tid + "')\"></select>";
+	var list = document.getElementById(lid);
+	if (!list) {
+		if (spinElement) spinElement.style.display = 'none';
+		if (scanButton) scanButton.disabled = 0;
+		return;
+	}
+
+	list.dataset.originalWidth = widthValue;
+	list.dataset.originalMinWidth = minWidthValue;
+	applyElementSize(list, widthValue, minWidthValue);
+
+	while (list.firstChild) list.removeChild(list.firstChild);
+
+	xob = new XmlHttp();
+	xob.onCompleted = function(text, xml) {
+		try {
+			if (spinElement) spinElement.style.display = 'none';
+			if (scanButton) scanButton.disabled = 0;
+
+			while (list.firstChild) list.removeChild(list.firstChild);
+			var header = document.createElement('option');
+			header.value = '';
+			header.text = '❮❮ Scan result ❯❯';
+			header.disabled = true;
+			header.style.color = 'grey';
+			header.selected = true;
+			list.appendChild(header);
+
+			function _ssidLabel(s) {
+				s = (s || '').toString().trim();
+				return (s === '') ? '[ hidden ]' : s;
+			}
+
+			wlscandata = [];
+			eval(text);
+
+			var ssidEl = document.getElementsByName('wl' + unit + '_ssid')[0];
+			var filterSsid = ssidEl ? ((ssidEl.value || '').toString().trim()) : '';
+			var seen = {};
+			wlscandata.forEach(function(data) {
+				var mac = (data[0] || '').toString().trim();
+				var ssid = (data[1] || '').toString().trim();
+				var quality = (data[5] * 1);
+
+				if (mac === '' || seen[mac]) return;
+
+				if (applySsidFilter && filterSsid !== '') {
+					if (ssid !== filterSsid) return;
+				}
+
+				seen[mac] = true;
+				var o = document.createElement('option');
+				o.value = mac;
+				o.text = _ssidLabel(ssid) + ' - ' + mac + ' - ' + ' 🛜 ' + quality + '%';
+				list.appendChild(o);
+			});
+		} catch (x) {
+			console.error(x);
+		}
+
+		try {
+			if (!list.firstChild) {
+				var header = document.createElement('option');
+				header.value = '';
+				header.text = '❮❮ Scan result ❯❯';
+				header.disabled = true;
+				header.style.color = 'grey';
+				header.selected = true;
+				list.appendChild(header);
+			}
+			var typeManuallyOption = document.createElement('option');
+			typeManuallyOption.value = 'manual';
+			typeManuallyOption.text = '❯❯ Switch to manual input ❮❮';
+			list.appendChild(typeManuallyOption);
+		} catch (x2) {
+		}
+
+		list.style.display = '';
+
+		xob = null;
+	};
+	xob.onError = function(x) {
+		alert('error: ' + x);
+		try {
+			while (list.firstChild) list.removeChild(list.firstChild);
+			var header = document.createElement('option');
+			header.value = '';
+			header.text = '❮❮ Scan result ❯❯';
+			header.disabled = true;
+			header.style.color = 'grey';
+			header.selected = true;
+			list.appendChild(header);
+			var typeManuallyOption = document.createElement('option');
+			typeManuallyOption.value = 'manual';
+			typeManuallyOption.text = '❯❯ Switch to manual input ❮❮';
+			list.appendChild(typeManuallyOption);
+			list.style.display = '';
+		} catch (x2) {
+		}
+		if (spinElement) spinElement.style.display = 'none';
+		if (scanButton) scanButton.disabled = 0;
+		xob = null;
+	};
+	xob.post('update.cgi', 'exec=wlscan&arg0=' + unit);
+}
+
+function selectBSSID(select, unit, targetId) {
+	var tid = targetId || ('_f_wl' + unit + '_clap_hwaddr');
+	var macInput = document.createElement('input');
+	macInput.type = 'text';
+	macInput.name = select.name;
+	macInput.id = tid;
+
+	var widthInfo = {
+		width: select.dataset.originalWidth || select.style.width,
+		minWidth: select.dataset.originalMinWidth || select.style.minWidth
+	};
+	applyElementSize(macInput, widthInfo.width, widthInfo.minWidth);
+	macInput.style.visibility = 'hidden';
+	var parent = select.parentNode;
+	parent.insertBefore(macInput, select);
+	parent.removeChild(select);
+	macInput.style.visibility = '';
+
+	if (select.value === 'manual') {
+		macInput.value = '';
+		return;
+	}
+
+	macInput.value = (select.value || '').toString().trim();
+	verifyFields(macInput, 1);
+}
+
+function clearBssidIfPresent(u) {
+	var tid = '_f_wl' + u + '_clap_hwaddr';
+	var selectEl = E('macList' + u);
+	var targetEl = E(tid);
+	if (selectEl) {
+		var width = selectEl.dataset.originalWidth || selectEl.style.width;
+		var minWidth = selectEl.dataset.originalMinWidth || selectEl.style.minWidth || width;
+		var macInput = document.createElement('input');
+		macInput.type = 'text';
+		macInput.name = selectEl.name;
+		macInput.id = tid;
+		macInput.value = '';
+		applyElementSize(macInput, width, minWidth);
+		macInput.style.visibility = 'hidden';
+		var parent = selectEl.parentNode;
+		parent.insertBefore(macInput, selectEl);
+		parent.removeChild(selectEl);
+		macInput.style.visibility = '';
+		return;
+	}
+
+	if (targetEl) {
+		targetEl.value = '';
+		var width = targetEl.dataset.originalWidth || targetEl.style.width;
+		var minWidth = targetEl.dataset.originalMinWidth || targetEl.style.minWidth || width;
+		applyElementSize(targetEl, width, minWidth);
+	}
 }
 
 function joinAddr(a) {
@@ -265,16 +583,55 @@ function joinAddr(a) {
 }
 
 function random_x(max) {
-	var c = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
-	var s = '';
-	while (max-- > 0) s += c.substr(Math.floor(c.length * Math.random()), 1);
+	var lower = 'abcdefghijklmnopqrstuvwxyz';
+	var upper = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+	var digits = '0123456789';
+	var specials = '!@#$%^&*-_+=';
+	var all = lower + upper + digits + specials;
+	var chars = [];
+	var pct = Math.round(max * 0.16);
 
-	return s;
+	// Ensure 16% of each character type
+	for (var i = 0; i < pct; ++i) {
+		chars.push(upper.charAt(Math.floor(Math.random() * upper.length)));
+		chars.push(lower.charAt(Math.floor(Math.random() * lower.length)));
+		chars.push(digits.charAt(Math.floor(Math.random() * digits.length)));
+		chars.push(specials.charAt(Math.floor(Math.random() * specials.length)));
+	}
+
+	// Fill remainder with random characters
+	while (chars.length < max)
+		chars.push(all.charAt(Math.floor(Math.random() * all.length)));
+
+	// Shuffle with Fisher-Yates
+	for (var i = chars.length - 1; i > 0; --i) {
+		var j = Math.floor(Math.random() * (i + 1));
+		var temp = chars[i];
+		chars[i] = chars[j];
+		chars[j] = temp;
+	}
+
+	return chars.join('');
 }
 
-function random_psk(id) {
+function random_psk(id, selectId) {
 	var e = E(id);
-	e.value = random_x(63);
+	var sel = selectId ? E(selectId) : null;
+	var val = sel ? sel.value : '';
+
+	if (sel) sel.selectedIndex = 0;
+
+	if (val === 'clear') {
+		e.value = '';
+		ferror.clear(e);
+		return;
+	}
+
+	var len = parseInt(val, 10) || 0;
+	if (len < 8 || len > 63)
+		len = Math.floor(Math.random() * 56) + 8;
+
+	e.value = random_x(len);
 	verifyFields(null, 1);
 }
 
@@ -306,8 +663,10 @@ function v_wep(e, quiet) {
 /* compatible w/ Linksys' and Netgear's (key 1) method for 128-bits */
 function generate_wep(u) {
 	function _wepgen(pass, i) {
-		while (pass.length < 64) pass += pass;
-		return hex_md5(pass.substr(0, 64)).substr(i, (E('_wl'+u+'_wep_bit').value == 128) ? 26 : 10);
+		var seed = pass || '';
+		if (!seed.length) return '';
+		while (seed.length < 64) seed += seed;
+		return hex_md5(seed.substr(0, 64)).substr(i, (E('_wl'+u+'_wep_bit').value == 128) ? 26 : 10);
 	}
 
 	var e = E('_wl'+u+'_passphrase');


### PR DESCRIPTION
- basic+virtual: New SSID Scan function
- basic+virtual: New BSSID scan function
- basic+virtual: Rearranged options and adjusted indent
- basic+virtual: Hiding for certain Wireless Modes e.g. where Auto is required this is now hidden
- basic+virtual: New Shared Key [Random] option allowing different password length
- basic+virtual: Introduced *some* special characters in the [Random] generated password
- basic+virtual: WDS - renamed “Automatic” to “Open” and “Link With...” to “Restricted”
- virtual: Hide tabs whose interface is not enabled under Overview
- virtual: Added SSID name to the tabs
- virtual: Added frequencies (e.g. / 2.4 GHz) to virtual interfaces and tab names
- virtual: Added for Wireless Client to get/display/set the WANx bridge mapping of reference
- virtual: Removed for Wireless Client any reference to LANx under bridge
- virtual: Renamed "Enable interface" to simply "Enable"
- virtual: Security parameters are now fully hidden if Security = Disabled (like the basic network does)