### PR TITLE
rc: suspend multi-wan-watchdog during PPP connection setup

### DIFF
--- a/release/src-rt-6.x.4708/router/others/mwwatchdog
+++ b/release/src-rt-6.x.4708/router/others/mwwatchdog
@@ -122,7 +122,7 @@ mwwatchdogRun() {
 
 			DEFAULT_ROUTE_FRAGMENT=$(ip route | grep default | cut -d' ' -f2-)
 			GATEWAY_FRAGMENT="via $(NG "$PREFIX"_gateway)"
-			[ "$ISPPPD" -eq 1 ] && GATEWAY_FRAGMENT=""
+			[ "$ISPPPD" -eq 1 ] && { GATEWAY_FRAGMENT=""; SOURCE_ADDR=$(NG "$PREFIX"_ppp_get_ip); }
 
 			# add routes
 			for IP in $IPLIST; do
@@ -213,7 +213,11 @@ cktracert() {
 		RXBYTES1=${RXBYTES1:-0}
 		[ "$RXBYTES1" = "0" ] && $LOGD "failed to read initial rx_bytes for $IFACE (using 0)"
 
-		traceroute -i "$IFACE" -n -w 1 -m 10 -q 1 -z 1 "$IP" &>/dev/null
+		if [ "$ISPPPD" -eq 1 ]; then
+			traceroute -s "$SOURCE_ADDR" -n -w 1 -m 10 -q 1 -z 1 "$IP" 2>/dev/null
+		else
+			traceroute -i "$IFACE" -n -w 1 -m 10 -q 1 -z 1 "$IP" 2>/dev/null
+		fi
 		sleep 1
 
 		RXBYTES2=$(cat /sys/class/net/$IFACE/statistics/rx_bytes 2>/dev/null || echo 0)
@@ -247,7 +251,11 @@ ckping() {
 	for IP in $IPLIST; do
 		i=$((i+1))
 		# 0 means 100% loss - no packages received
-		ping -c $((i+1)) -A -W $((i+2)) -q -I "$IFACE" "$IP" >/dev/null 2>&1 && RESULT=$((RESULT+1))
+		if [ "$ISPPPD" -eq 1 ]; then
+			ping -c $((i+1)) -A -W $((i+2)) -q -I "$SOURCE_ADDR" "$IP" >/dev/null 2>&1 && RESULT=$((RESULT+1))
+		else
+			ping -c $((i+1)) -A -W $((i+2)) -q -I "$IFACE" "$IP" >/dev/null 2>&1 && RESULT=$((RESULT+1))
+		fi
 		[ "$RESULT" -gt 0 ] && break
 	done
 

--- a/release/src-rt-6.x.4708/router/rc/mwan.c
+++ b/release/src-rt-6.x.4708/router/rc/mwan.c
@@ -176,7 +176,7 @@ void mwan_table_add(char *sPrefix)
 	char cmd[256];
 	char buf[32];
 
-	logmsg(LOG_DEBUG, "*** %s IN", __FUNCTION__);
+	logmsg(LOG_DEBUG, "*** %s IN for %s", __FUNCTION__, sPrefix);
 
 	/* delete already existed table first */
 	mwan_table_del(sPrefix);

--- a/release/src-rt-6.x.4708/router/rc/ppp.c
+++ b/release/src-rt-6.x.4708/router/rc/ppp.c
@@ -53,7 +53,8 @@
 int ipup_main(int argc, char **argv)
 {
 	char *wan_ifname;
-	int proto;
+	int proto, old_ck_pause = 0;
+	int check_mwandog = nvram_get_int("mwan_cktime");
 	char prefix[] = "wanXX";
 	char tmp[100], tmp2[32];
 	char ppplink_file[32];
@@ -73,6 +74,21 @@ int ipup_main(int argc, char **argv)
 	if ((!wan_ifname) || (!*wan_ifname))
 		return -1;
 
+	/* check mwwatchdog enabled - part 1 of 2 */
+	if (check_mwandog) {
+		memset(tmp2, 0, sizeof(tmp2));
+		snprintf(tmp2, sizeof(tmp2), "%s_ck_pause", prefix);
+		old_ck_pause = nvram_get_int(tmp2); /* save old value */
+		nvram_set(tmp2, "1"); /* skip checking on this WAN until start_wan_done() finished! */
+		logmsg(LOG_DEBUG, "*** %s: set %s_ck_pause=1 to skip checking on this WAN (multiwan watchdog)", __FUNCTION__, prefix);
+	}
+
+	/* Note: User can set multi wan init state file with value "0" or "1" (default value)
+	 * see function mwan_state_files(void)
+	 * use nvram set mwan_state_init=0
+	 * to set state file with value "0" instead of "1"
+	 */
+	
 	nvram_set(strlcat_r(prefix, "_iface", tmp, sizeof(tmp)), wan_ifname); /* ppp# */
 	nvram_set(strlcat_r(prefix, "_pppd_pid", tmp, sizeof(tmp)), safe_getenv("PPPD_PID"));
 
@@ -139,6 +155,14 @@ int ipup_main(int argc, char **argv)
 
 	logmsg(LOG_DEBUG, "*** OUT %s: to start_wan_done, ifname=%s prefix=%s ...", __FUNCTION__, wan_ifname, prefix);
 	start_wan_done(wan_ifname, prefix);
+
+	/* check mwwatchdog enabled - part 2 of 2 */
+	if (check_mwandog && !old_ck_pause) {
+		memset(tmp2, 0, sizeof(tmp2));
+		snprintf(tmp2, sizeof(tmp2), "%s_ck_pause", prefix);
+		nvram_set(tmp2, "0"); /* reset and check WAN XY with mwwatchdog again */
+		logmsg(LOG_DEBUG, "*** %s: set %s_ck_pause=0 to check this WAN (multiwan watchdog)", __FUNCTION__, prefix);
+	}
 
 	return 0;
 }
@@ -252,6 +276,8 @@ int ip6up_main(int argc, char **argv)
 	if (!wait_action_idle(10))
 		return -1;
 
+	/* ToDo: check mwwatchdog enabled for case IPv6! missing so far! */
+	
 	wan_ifname = safe_getenv("IFNAME");
 	strlcpy(prefix, safe_getenv("LINKNAME"), sizeof(prefix));
 	logmsg(LOG_DEBUG, "*** %s: wan_ifname = %s, prefix = %s.", __FUNCTION__, wan_ifname, prefix);

--- a/release/src-rt-6.x.4708/router/shared/misc.c
+++ b/release/src-rt-6.x.4708/router/shared/misc.c
@@ -687,7 +687,7 @@ state:
 		fscanf(f, "%d", &up);
 		fclose(f);
 	}
-
+	logmsg(LOG_DEBUG, "*** %s: state of %s is %d", __FUNCTION__, prefix, up);
 	return up;
 }
 


### PR DESCRIPTION
see mips issue https://github.com/FreshTomato-Project/freshtomato-mips/pull/45

THX to pedro & chrismuller

1) tracert test result:
Mar  6 11:00:18 R7000 daemon.info pppd[7609]: Remote message: SRU=300000#SRD=600000#ISP=DTAG Mar  6 11:00:18 R7000 daemon.notice pppd[7609]: PAP authentication succeeded Mar  6 11:00:18 R7000 daemon.notice pppd[7609]: peer from calling number 28:AA:BB:FF:00:76 authorized Mar  6 11:00:18 R7000 daemon.notice pppd[7609]: local  IP address 79.222.111.32 Mar  6 11:00:18 R7000 daemon.notice pppd[7609]: remote IP address 62.111.222.253
Mar  6 11:00:18 R7000 daemon.notice pppd[7609]: primary   DNS address 217.233.144.122
Mar  6 11:00:18 R7000 daemon.notice pppd[7609]: secondary DNS address 217.233.155.122
Mar  6 11:00:18 R7000 daemon.notice pppd[7609]: local  LL address fe80::3d11:aaaa:bbbb:abd9
Mar  6 11:00:18 R7000 daemon.notice pppd[7609]: remote LL address fe80::2a11:aaaa:bbbb:ab76
Mar  6 11:00:18 R7000 user.info ip-up[7652]: *** ipup_main: wan_ifname = ppp0, prefix = wan.
Mar  6 11:00:18 R7000 user.info ip-up[7652]: *** ipup_main: set wan_ck_pause=1 to skip checking on this WAN (multiwan watchdog)
Mar  6 11:00:18 R7000 user.info ip-up[7652]: *** OUT ipup_main: to start_wan_done, ifname=ppp0 prefix=wan ...
...
Mar  6 11:00:47 R7000 daemon.notice miniupnpd[7746]: shutting down MiniUPnPd
Mar  6 11:00:52 R7000 daemon.notice miniupnpd[8095]: version 2.3.7 started
Mar  6 11:00:52 R7000 daemon.notice miniupnpd[8095]: HTTP listening on port 55404
Mar  6 11:00:52 R7000 daemon.notice miniupnpd[8095]: HTTP IPv6 address given to control points : [2003:f3:2fbb:aaaa::1]
Mar  6 11:00:52 R7000 daemon.notice miniupnpd[8095]: Listening for NAT-PMP/PCP traffic on port 5351
Mar  6 11:00:59 R7000 user.info ip-up[7652]: *** ipup_main: set wan_ck_pause=0 to check this WAN (multiwan watchdog)
Mar  6 11:01:00 R7000 cron.info crond[7467]: USER root pid 8293 cmd /usr/sbin/mwwatchdog
Mar  6 11:01:00 R7000 user.debug mwwatchdog[8293]: ip route add 172.211.168.77 via 62.151.241.211 dev ppp0
Mar  6 11:01:00 R7000 user.debug mwwatchdog[8293]: ip route add 172.211.168.77 dev ppp0 metric 50000
Mar  6 11:01:00 R7000 user.debug mwwatchdog[8293]: ip route add 13.117.244.44 via 62.151.241.211 dev ppp0
Mar  6 11:01:00 R7000 user.debug mwwatchdog[8293]: ip route add 13.117.244.44 dev ppp0 metric 50000
Mar  6 11:01:00 R7000 user.debug mwwatchdog[8293]: start test for: ppp0 ...
Mar  6 11:01:01 R7000 user.debug mwwatchdog[8293]: tracert test result for: ppp0 - OK
Mar  6 11:01:01 R7000 user.debug mwwatchdog[8293]: ip route del 172.211.168.77 via 62.151.241.211 dev ppp0
Mar  6 11:01:01 R7000 user.debug mwwatchdog[8293]: ip route del 172.211.168.77 dev ppp0 metric 50000
Mar  6 11:01:01 R7000 user.debug mwwatchdog[8293]: ip route del 13.117.244.44 via 62.151.241.211 dev ppp0
Mar  6 11:01:01 R7000 user.debug mwwatchdog[8293]: ip route del 13.117.244.44 dev ppp0 metric 50000
Mar  6 11:01:01 R7000 user.debug mwwatchdog[8293]: Connection WAN0 is functioning
Mar  6 11:01:07 R7000 user.info redial[7610]: *** check_wanup: state of wan is 1
Mar  6 11:01:27 R7000 user.info redial[7610]: *** check_wanup: state of wan is 1
Mar  6 11:01:47 R7000 user.info redial[7610]: *** check_wanup: state of wan is 1
Mar  6 11:02:00 R7000 cron.info crond[7467]: USER root pid 8664 cmd /usr/sbin/mwwatchdog
...

2) ping test result:
Mar  6 10:53:45 R7000 daemon.notice miniupnpd[3847]: shutting down MiniUPnPd Mar  6 10:53:51 R7000 daemon.notice miniupnpd[4330]: version 2.3.7 started Mar  6 10:53:51 R7000 daemon.notice miniupnpd[4330]: HTTP listening on port 48532 Mar  6 10:53:51 R7000 daemon.notice miniupnpd[4330]: HTTP IPv6 address given to control points : [2003:f3:2fbb:aaaa::1] Mar  6 10:53:51 R7000 daemon.notice miniupnpd[4330]: Listening for NAT-PMP/PCP traffic on port 5351 Mar  6 10:53:51 R7000 daemon.warn dnsmasq[4351]: possible DNS-rebind attack detected: dns.msftncsi.com Mar  6 10:53:57 R7000 user.info ip-up[3715]: *** ipup_main: set wan_ck_pause=0 to check this WAN (multiwan watchdog) Mar  6 10:54:00 R7000 cron.info crond[929]: USER root pid 4432 cmd /usr/sbin/mwwatchdog Mar  6 10:54:00 R7000 user.debug mwwatchdog[4432]: ip route add 142.251.36.110 via 62.151.241.211 dev ppp0 Mar  6 10:54:00 R7000 user.debug mwwatchdog[4432]: ip route add 142.251.36.110 dev ppp0 metric 50000 Mar  6 10:54:00 R7000 user.debug mwwatchdog[4432]: ip route add 13.117.244.44 via 62.151.241.211 dev ppp0 Mar  6 10:54:00 R7000 user.debug mwwatchdog[4432]: ip route add 13.117.244.44 dev ppp0 metric 50000 Mar  6 10:54:00 R7000 user.debug mwwatchdog[4432]: start test for: ppp0 ... Mar  6 10:54:00 R7000 user.debug mwwatchdog[4432]: ping test result for: ppp0 - OK Mar  6 10:54:00 R7000 user.debug mwwatchdog[4432]: ip route del 142.251.36.110 via 62.151.241.211 dev ppp0 Mar  6 10:54:00 R7000 user.debug mwwatchdog[4432]: ip route del 142.251.36.110 dev ppp0 metric 50000 Mar  6 10:54:00 R7000 user.debug mwwatchdog[4432]: ip route del 13.117.244.44 via 62.151.241.211 dev ppp0 Mar  6 10:54:00 R7000 user.debug mwwatchdog[4432]: ip route del 13.117.244.44 dev ppp0 metric 50000 Mar  6 10:54:00 R7000 user.debug mwwatchdog[4432]: Connection WAN0 is functioning Mar  6 10:54:05 R7000 user.info redial[3363]: *** check_wanup: state of wan is 1