### PR TITLE
porthealth - fix for nvram variable and defaults

### DIFF
--- a/release/src-rt-6.x.4708/router/httpd/tomato.c
+++ b/release/src-rt-6.x.4708/router/httpd/tomato.c
@@ -698,6 +698,9 @@ static const nvset_t nvset_list[] = {
 #ifdef TCONFIG_BCMNAT
 	{ "bcmnat_disable",		V_01				},
 #endif
+#ifdef TCONFIG_BCMARM
+	{ "porthealth_cfg",		V_LENGTH(0, 128)		},
+#endif
 /* advanced-vlan */
 	{ "vlan0ports",			V_TEXT(0, 17)			},
 	{ "vlan1ports",			V_TEXT(0, 17)			},

--- a/release/src-rt-6.x.4708/router/rc/services.c
+++ b/release/src-rt-6.x.4708/router/rc/services.c
@@ -103,7 +103,7 @@ static pid_t pid_phy_tempsense = -1;
  * - Managed via cron (cru)
  * - Script installed at: /usr/sbin/porthealth.sh
  * - Settings in nvram: porthealth_cfg
- *   Format: enable=1,mode=monitor,max=50,hold=180,cache=60,if=l
+ *   Format: enable=1,mode=monitor,max=10,hold=180,cache=900,if=l
  */
 #ifdef TCONFIG_BCMARM
 static void stop_porthealth(void)
@@ -124,9 +124,9 @@ static void start_porthealth(void)
 	char *k;
 	char *v;
 	int enable = 0;
-	int max_i = 50;
+	int max_i = 10;
 	int hold_i = 180;
-	int cache_i = 60;
+	int cache_i = 900;
 	const char *cfg;
 
 	stop_porthealth();

--- a/release/src-rt-6.x.4708/router/shared/defaults.c
+++ b/release/src-rt-6.x.4708/router/shared/defaults.c
@@ -938,6 +938,9 @@ struct nvram_tuple router_defaults[] = {
 #ifdef TCONFIG_BCMNAT
 	{ "bcmnat_disable",		"1"				, 0 },
 #endif
+#ifdef TCONFIG_BCMARM
+	{ "porthealth_cfg",		""				, 0 },
+#endif
 
 /* advanced-dhcpdns */
 	{ "dhcpd_dmdns",		"1"				, 0 },

--- a/release/src-rt-6.x.4708/router/www/advanced-misc.asp
+++ b/release/src-rt-6.x.4708/router/www/advanced-misc.asp
@@ -8,194 +8,212 @@
 	No part of this file may be used without permission.
 -->
 <html lang="en-GB">
+
 <head>
-<meta http-equiv="content-type" content="text/html;charset=utf-8">
-<meta name="robots" content="noindex,nofollow">
-<title>[<% ident(); %>] Advanced: Miscellaneous</title>
-<link rel="stylesheet" type="text/css" href="tomato.css?rel=<% version(); %>">
-<% css(); %>
-<script src="tomato.js?rel=<% version(); %>"></script>
+	<meta http-equiv="content-type" content="text/html;charset=utf-8">
+	<meta name="robots" content="noindex,nofollow">
+	<title>[<% ident(); %>] Advanced: Miscellaneous</title>
+	<link rel="stylesheet" type="text/css" href="tomato.css?rel=<% version(); %>">
+	<% css(); %>
+		<script src="tomato.js?rel=<% version(); %>"></script>
 
-<script>
+		<script>
 
-//	<% nvram("t_features,wait_time,wan_speed,jumbo_frame_enable,jumbo_frame_size,ctf_disable,bcmnat_disable,porthealth_cfg"); %>
+			//	<% nvram("t_features,wait_time,wan_speed,jumbo_frame_enable,jumbo_frame_size,ctf_disable,bcmnat_disable,porthealth_cfg"); %>
 
-et1000 = features('1000et');
+			et1000 = features('1000et');
 
-function _phTrim(s) {
-	return (s || '').replace(/^\s+|\s+$/g, '');
-}
+			function _phTrim(s) {
+				return (s || '').replace(/^\s+|\s+$/g, '');
+			}
 
-function _phCfg() {
-	var cfg = nvram.porthealth_cfg || '';
-	var o = { enable: 0, mode: 'monitor', max: 50, hold: 180, cache: 60, ift: 'l' };
-	var parts, i, kv, k, v;
+			function _phCfg() {
+				var cfg = nvram.porthealth_cfg || '';
+				var o = { enable: 0, mode: 'monitor', max: 10, hold: 180, cache: 9000, ift: 'l' };
+				var parts, i, kv, k, v;
 
-	cfg = _phTrim(cfg);
-	if (cfg.length == 0) return o;
+				cfg = _phTrim(cfg);
+				if (cfg.length == 0) return o;
 
-	parts = cfg.split(',');
-	for (i = 0; i < parts.length; ++i) {
-		kv = parts[i].split('=');
-		if (kv.length < 2) continue;
-		k = _phTrim(kv[0]);
-		v = _phTrim(kv.slice(1).join('='));
-		if (k == 'enable') o.enable = (v == '1') ? 1 : 0;
-		else if (k == 'mode') o.mode = v;
-		else if (k == 'max') o.max = v * 1;
-		else if (k == 'hold') o.hold = v * 1;
-		else if (k == 'cache') o.cache = v * 1;
-		else if (k == 'if') o.ift = v;
-	}
+				parts = cfg.split(',');
+				for (i = 0; i < parts.length; ++i) {
+					kv = parts[i].split('=');
+					if (kv.length < 2) continue;
+					k = _phTrim(kv[0]);
+					v = _phTrim(kv.slice(1).join('='));
+					if (k == 'enable') o.enable = (v == '1') ? 1 : 0;
+					else if (k == 'mode') o.mode = v;
+					else if (k == 'max') o.max = v * 1;
+					else if (k == 'hold') o.hold = v * 1;
+					else if (k == 'cache') o.cache = v * 1;
+					else if (k == 'if') o.ift = v;
+				}
 
-	if ((o.mode != 'monitor') && (o.mode != 'recover') && (o.mode != 'disable')) o.mode = 'monitor';
-	if ((o.ift != 'l') && (o.ift != 'w') && (o.ift != 'a')) o.ift = 'l';
-	o.max = fixInt(o.max, 1, 100000, 50);
-	o.hold = fixInt(o.hold, 1, 86400, 180);
-	o.cache = fixInt(o.cache, 0, 86400, 60);
+				if ((o.mode != 'monitor') && (o.mode != 'recover') && (o.mode != 'disable')) o.mode = 'monitor';
+				if ((o.ift != 'l') && (o.ift != 'w') && (o.ift != 'a')) o.ift = 'l';
 
-	return o;
-}
+				o.max = fixInt(o.max, 1, 100000, 10);
+				o.hold = fixInt(o.hold, 1, 86400, 180);
+				o.cache = fixInt(o.cache, 0, 86400, 900);
 
-function verifyFields(focused, quiet) {
-	E('_jumbo_frame_size').disabled = !E('_f_jumbo_frame_enable').checked;
+				return o;
+			}
 
-	if (!v_range(E('_f_porthealth_max'), quiet, 1, 100000)) return 0;
-	if (!v_range(E('_f_porthealth_hold'), quiet, 1, 86400)) return 0;
-	if (!v_range(E('_f_porthealth_cache'), quiet, 0, 86400)) return 0;
+			function verifyFields(focused, quiet) {
+				E('_jumbo_frame_size').disabled = !E('_f_jumbo_frame_enable').checked;
 
-	return 1;
-}
+				if (!v_range(E('_f_porthealth_max'), quiet, 1, 100000)) return 0;
+				if (!v_range(E('_f_porthealth_hold'), quiet, 1, 86400)) return 0;
+				if (!v_range(E('_f_porthealth_cache'), quiet, 0, 86400)) return 0;
 
-function save() {
-	var fom = E('t_fom');
-	var ph;
+				return 1;
+			}
 
-	if (!verifyFields(null, 0))
-		return;
+			function save() {
+				var fom = E('t_fom');
+				var ph;
 
-	fom.jumbo_frame_enable.value = E('_f_jumbo_frame_enable').checked ? 1 : 0;
-/* CTF-BEGIN */
-	fom.ctf_disable.value = E('_f_ctf_disable').checked ? 0 : 1;
-/* CTF-END */
-/* BCMNAT-BEGIN */
-	fom.bcmnat_disable.value = E('_f_bcmnat_disable').checked ? 0 : 1;
-/* BCMNAT-END */
+				if (!verifyFields(null, 0))
+					return;
 
-	/* Port Health */
-	ph = {
-		enable: E('_f_porthealth_enable').checked ? 1 : 0,
-		mode: E('_f_porthealth_mode').value,
-		max: E('_f_porthealth_max').value,
-		hold: E('_f_porthealth_hold').value,
-		cache: E('_f_porthealth_cache').value,
-		ift: E('_f_porthealth_if').value
-	};
-	fom.porthealth_cfg.value = 'enable=' + (ph.enable ? 1 : 0) +
-		',mode=' + ph.mode +
-		',max=' + ph.max +
-		',hold=' + ph.hold +
-		',cache=' + ph.cache +
-		',if=' + ph.ift;
+				fom.jumbo_frame_enable.value = E('_f_jumbo_frame_enable').checked ? 1 : 0;
+				/* CTF-BEGIN */
+				fom.ctf_disable.value = E('_f_ctf_disable').checked ? 0 : 1;
+				/* CTF-END */
+				/* BCMNAT-BEGIN */
+				fom.bcmnat_disable.value = E('_f_bcmnat_disable').checked ? 0 : 1;
+				/* BCMNAT-END */
 
-	if ((fom.wan_speed.value != nvram.wan_speed) ||
-/* CTF-BEGIN */
-	    (fom.ctf_disable.value != nvram.ctf_disable) ||
-/* CTF-END */
-/* BCMNAT-BEGIN */
-	    (fom.bcmnat_disable.value != nvram.bcmnat_disable) ||
-/* BCMNAT-END */
-	    (fom.jumbo_frame_enable.value != nvram.jumbo_frame_enable) ||
-	    (fom.jumbo_frame_size.value != nvram.jumbo_frame_size)) {
-		if (confirm("Router must be rebooted to apply changed settings. Reboot now? (and commit changes to NVRAM)")) {
-			fom._reboot.value = 1;
-			form.submit(fom, 0);
-		}
-		else { /* countinue without reboot (user wants it that way) */
-			form.submit(fom, 1);
-		}
-	}
-	else { /* continue without reboot */
-		form.submit(fom, 1);
-	}
-}
-</script>
+				/* Port Health */
+				ph = {
+					enable: E('_f_porthealth_enable').checked ? 1 : 0,
+					mode: E('_f_porthealth_mode').value,
+					max: E('_f_porthealth_max').value,
+					hold: E('_f_porthealth_hold').value,
+					cache: E('_f_porthealth_cache').value,
+					ift: E('_f_porthealth_if').value
+				};
+				fom.porthealth_cfg.value = 'enable=' + (ph.enable ? 1 : 0) +
+					',mode=' + ph.mode +
+					',max=' + ph.max +
+					',hold=' + ph.hold +
+					',cache=' + ph.cache +
+					',if=' + ph.ift;
+
+				if ((fom.wan_speed.value != nvram.wan_speed) ||
+					/* CTF-BEGIN */
+					(fom.ctf_disable.value != nvram.ctf_disable) ||
+					/* CTF-END */
+					/* BCMNAT-BEGIN */
+					(fom.bcmnat_disable.value != nvram.bcmnat_disable) ||
+					/* BCMNAT-END */
+					(fom.jumbo_frame_enable.value != nvram.jumbo_frame_enable) ||
+					(fom.jumbo_frame_size.value != nvram.jumbo_frame_size)) {
+					if (confirm("Router must be rebooted to apply changed settings. Reboot now? (and commit changes to NVRAM)")) {
+						fom._reboot.value = 1;
+						form.submit(fom, 0);
+					}
+					else { /* countinue without reboot (user wants it that way) */
+						form.submit(fom, 1);
+					}
+				}
+				else { /* continue without reboot */
+					form.submit(fom, 1);
+				}
+			}
+		</script>
 </head>
 
 <body>
-<form id="t_fom" method="post" action="tomato.cgi">
-<table id="container">
-<tr><td colspan="2" id="header">
-	<div class="title"><a href="/">FreshTomato</a></div>
-	<div class="version">Version <% version(); %> on <% nv("t_model_name"); %><span class="blinking bl2"><script><% anonupdate(); %> anon_update()</script>&nbsp;</span></div>
-</td></tr>
-<tr id="body"><td id="navi"><script>navi()</script></td>
-<td id="content">
-<div id="ident"><% ident(); %> | <script>wikiLink();</script></div>
+	<form id="t_fom" method="post" action="tomato.cgi">
+		<table id="container">
+			<tr>
+				<td colspan="2" id="header">
+					<div class="title"><a href="/">FreshTomato</a></div>
+					<div class="version">Version <% version(); %> on <% nv("t_model_name"); %><span
+									class="blinking bl2">
+									<script><% anonupdate(); %> anon_update()</script>&nbsp;
+								</span></div>
+				</td>
+			</tr>
+			<tr id="body">
+				<td id="navi">
+					<script>navi()</script>
+				</td>
+				<td id="content">
+					<div id="ident">
+						<% ident(); %> |
+							<script>wikiLink();</script>
+					</div>
 
-<!-- / / / -->
+					<!-- / / / -->
 
-<input type="hidden" name="_nextpage" value="advanced-misc.asp">
-<input type="hidden" name="_reboot" value="0">
-<input type="hidden" name="_service" value="porthealth-restart">
-<input type="hidden" name="jumbo_frame_enable">
-<!-- CTF-BEGIN -->
-<input type="hidden" name="ctf_disable">
-<!-- CTF-END -->
-<!-- BCMNAT-BEGIN -->
-<input type="hidden" name="bcmnat_disable">
-<!-- BCMNAT-END -->
+					<input type="hidden" name="_nextpage" value="advanced-misc.asp">
+					<input type="hidden" name="_reboot" value="0">
+					<input type="hidden" name="_service" value="porthealth-restart">
+					<input type="hidden" name="jumbo_frame_enable">
+					<!-- CTF-BEGIN -->
+					<input type="hidden" name="ctf_disable">
+					<!-- CTF-END -->
+					<!-- BCMNAT-BEGIN -->
+					<input type="hidden" name="bcmnat_disable">
+					<!-- BCMNAT-END -->
 
-<input type="hidden" name="porthealth_cfg">
+					<input type="hidden" name="porthealth_cfg">
 
-<!-- / / / -->
+					<!-- / / / -->
 
-<div class="section-title">Miscellaneous</div>
-<div class="section">
-	<script>
-		ph = _phCfg();
-		a = [];
-		for (i = 3; i <= 20; ++i) a.push([i, i + ' seconds']);
-		createFieldTable('', [
-			{ title: 'Boot Wait Time *', name: 'wait_time', type: 'select', options: a, value: fixInt(nvram.wait_time, 3, 20, 3) },
-			{ title: 'WAN Port Speed *', name: 'wan_speed', type: 'select', options: [[0,'10Mbps Full'],[1,'10Mbps Half'],[2,'100Mbps Full'],[3,'100Mbps Half'],[4,'Autonegotiation']], value: nvram.wan_speed },
-			null,
-/* CTF-BEGIN */
-			{ title: 'CTF (Cut-Through Forwarding)<br>and HW acceleration', name: 'f_ctf_disable', type: 'checkbox', value: nvram.ctf_disable != '1', suffix: ' <small>disables QoS and BW Limiter!<\/small>' },
-			null,
-/* CTF-END */
-/* BCMNAT-BEGIN */
-			{ title: 'Broadcom FastNAT (bcm_nat)', name: 'f_bcmnat_disable', type: 'checkbox', value: nvram.bcmnat_disable != '1', suffix: ' <small>disables BW Limiter; using QoS or Access Restriction disables this module!<\/small>' },
-/* BCMNAT-END */
-			{ title: 'Enable Jumbo Frames *', name: 'f_jumbo_frame_enable', type: 'checkbox', value: nvram.jumbo_frame_enable != '0', hidden: !et1000 },
-			{ title: 'Jumbo Frame Size *', name: 'jumbo_frame_size', type: 'text', maxlen: 4, size: 6, value: fixInt(nvram.jumbo_frame_size, 1, 9720, 2000),
-				suffix: ' <small>Bytes (range: 1 - 9720; default: 2000)<\/small>', hidden: !et1000 },
-			null,
-			{ title: 'Port Health', text: '<small>Monitors switch ports 0-4; VLAN role comes from robocfg show.<\/small>' },
-			{ title: 'Enable', name: 'f_porthealth_enable', type: 'checkbox', value: ph.enable == 1 },
-			{ title: 'Mode', name: 'f_porthealth_mode', type: 'select', value: ph.mode, options: [['monitor','Monitor (log only)'],['recover','Recover (step down speed)'],['disable','Disable port']] },
-			{ title: 'Ports', name: 'f_porthealth_if', type: 'select', value: ph.ift, options: [['l','LAN only'],['w','WAN only'],['a','LAN + WAN']] },
-			{ title: 'Max Errors / Minute', name: 'f_porthealth_max', type: 'text', value: ph.max, maxlen: 6, size: 8 },
-			{ title: 'Hold Time (seconds)', name: 'f_porthealth_hold', type: 'text', value: ph.hold, maxlen: 6, size: 8, suffix: ' <small>(recover mode only)<\/small>' },
-			{ title: 'Cache TTL (seconds)', name: 'f_porthealth_cache', type: 'text', value: ph.cache, maxlen: 6, size: 8, suffix: ' <small>(0 disables caching)<\/small>' }
-		]);
-	</script>
+					<div class="section-title">Miscellaneous</div>
+					<div class="section">
+						<script>
+							ph = _phCfg();
+							a = [];
+							for (i = 3; i <= 20; ++i) a.push([i, i + ' seconds']);
+							createFieldTable('', [
+								{ title: 'Boot Wait Time *', name: 'wait_time', type: 'select', options: a, value: fixInt(nvram.wait_time, 3, 20, 3) },
+								{ title: 'WAN Port Speed *', name: 'wan_speed', type: 'select', options: [[0, '10Mbps Full'], [1, '10Mbps Half'], [2, '100Mbps Full'], [3, '100Mbps Half'], [4, 'Autonegotiation']], value: nvram.wan_speed },
+								null,
+								/* CTF-BEGIN */
+								{ title: 'CTF (Cut-Through Forwarding)<br>and HW acceleration', name: 'f_ctf_disable', type: 'checkbox', value: nvram.ctf_disable != '1', suffix: ' <small>disables QoS and BW Limiter!<\/small>' },
+								null,
+								/* CTF-END */
+								/* BCMNAT-BEGIN */
+								{ title: 'Broadcom FastNAT (bcm_nat)', name: 'f_bcmnat_disable', type: 'checkbox', value: nvram.bcmnat_disable != '1', suffix: ' <small>disables BW Limiter; using QoS or Access Restriction disables this module!<\/small>' },
+								/* BCMNAT-END */
+								{ title: 'Enable Jumbo Frames *', name: 'f_jumbo_frame_enable', type: 'checkbox', value: nvram.jumbo_frame_enable != '0', hidden: !et1000 },
+								{
+									title: 'Jumbo Frame Size *', name: 'jumbo_frame_size', type: 'text', maxlen: 4, size: 6, value: fixInt(nvram.jumbo_frame_size, 1, 9720, 2000),
+									suffix: ' <small>Bytes (range: 1 - 9720; default: 2000)<\/small>', hidden: !et1000
+								},
+								null,
+								{ title: 'Port Health', text: '<small>Monitors switch ports 0-4; VLAN role comes from robocfg show.<\/small>' },
+								{ title: 'Enable', name: 'f_porthealth_enable', type: 'checkbox', value: ph.enable == 1 },
+								{ title: 'Mode', name: 'f_porthealth_mode', type: 'select', value: ph.mode, options: [['monitor', 'Monitor (log only)'], ['recover', 'Recover (step down speed)'], ['disable', 'Disable port']] },
+								{ title: 'Ports', name: 'f_porthealth_if', type: 'select', value: ph.ift, options: [['l', 'LAN only'], ['w', 'WAN only'], ['a', 'LAN + WAN']] },
+								{ title: 'Max Errors / Minute', name: 'f_porthealth_max', type: 'text', value: ph.max, maxlen: 6, size: 8, suffix: ' <small>(default: 10)<\/small>' },
+								{ title: 'Hold Time (seconds)', name: 'f_porthealth_hold', type: 'text', value: ph.hold, maxlen: 6, size: 8, suffix: ' <small>(recover mode only; default: 180)<\/small>' },
+								{ title: 'Cache TTL (seconds)', name: 'f_porthealth_cache', type: 'text', value: ph.cache, maxlen: 6, size: 8, suffix: ' <small>(0 disables caching; default: 900)<\/small>' }
+							]);
+						</script>
 
-	<div class="note-spacer"><small>* Some router models might not support this option.</small></div>
+						<div class="note-spacer"><small>* Some router models might not support this option.</small>
+						</div>
 
-</div>
+					</div>
 
-<!-- / / / -->
+					<!-- / / / -->
 
-<div id="footer">
-	<span id="footer-msg"></span>
-	<input type="button" value="Save" id="save-button" onclick="save()">
-	<input type="button" value="Cancel" id="cancel-button" onclick="reloadPage();">
-</div>
+					<div id="footer">
+						<span id="footer-msg"></span>
+						<input type="button" value="Save" id="save-button" onclick="save()">
+						<input type="button" value="Cancel" id="cancel-button" onclick="reloadPage();">
+					</div>
 
-</td></tr>
-</table>
-</form>
-<script>insOvl();verifyFields(null, true);</script>
+				</td>
+			</tr>
+		</table>
+	</form>
+	<script>insOvl(); verifyFields(null, true);</script>
 </body>
+
 </html>


### PR DESCRIPTION
It appears like the handling of the porthealth_cfg nvram variable was not part of the code that went into prod.

This fix is an attempt to:
- properly define the variable so that it can be read/written but .asp and script
- tweak the defaults on both nvram and .asp

In general the Max errors was too high (lowered from 50/min to 10/min) and the TTL should have been much higher (increased from 60 to 900 so 15 min).