### PR TITLE
tomato.js - Add case 'display' to handle span rendering

### DIFF
--- a/release/src-rt-6.x.4708/router/www/tomato.js
+++ b/release/src-rt-6.x.4708/router/www/tomato.js
@@ -1580,6 +1580,14 @@ TomatoGrid.prototype = {
 						else
 							s += '>';
 					break;
+						case 'display':
+							s += '<span'+attrib+'>';
+							if (which == 'edit')
+								s += escapeHTML(''+values[vi]);
+							else if (typeof f.value != 'undefined')
+								s += escapeHTML(''+f.value);
+							s += '</span>';
+						break;
 					case 'clear':
 						s += '';
 					break;


### PR DESCRIPTION
In the case where a table is composed by a mixture of input fields and read-only data, this new case 'display' helps handling the read-only information properly. It displays text in a cell without input fields, and doesn't prompt any input field when adding new records.

This allows for tables to be used in a more creative way like the MB column in this example:

			this.init('adblock-grid', '', 50, [
					{ type: 'checkbox', prefix: '<div class="centered">', suffix: '<\/div>' },
					{ type: 'text', maxlen: 130 },
					{ type: 'display', value: '', attrib: 'style="display:block;margin:0 auto"' },
					{ type: 'text', maxlen: 40 }
				]);

<img width="1294" height="258" alt="VrTy7ZlaHo" src="https://github.com/user-attachments/assets/4ae12d59-19e5-42ea-af96-195ad50f6c7e" />