### PR TITLE
Update advanced-misc.asp port health cache 900 default

### DIFF
--- a/release/src-rt-6.x.4708/router/www/advanced-misc.asp
+++ b/release/src-rt-6.x.4708/router/www/advanced-misc.asp
@@ -29,7 +29,7 @@ function _phTrim(s) {
 
 function _phCfg() {
 	var cfg = nvram.porthealth_cfg || '';
-	var o = { enable: 0, mode: 'monitor', max: 10, hold: 180, cache: 9000, ift: 'l' };
+	var o = { enable: 0, mode: 'monitor', max: 10, hold: 180, cache: 900, ift: 'l' };
 	var parts, i, kv, k, v;
 
 	cfg = _phTrim(cfg);


### PR DESCRIPTION
Either the default value is wrong being 9000 or the label for the default is wrong saying 900 one or the other.