### PR TITLE
Update advanced-misc.asp 1000mb full missing.

### DIFF
--- a/release/src-rt-6.x.4708/router/www/advanced-misc.asp
+++ b/release/src-rt-6.x.4708/router/www/advanced-misc.asp
@@ -166,7 +166,7 @@ function save() {
 		for (i = 3; i <= 20; ++i) a.push([i, i + ' seconds']);
 		createFieldTable('', [
 			{ title: 'Boot Wait Time *', name: 'wait_time', type: 'select', options: a, value: fixInt(nvram.wait_time, 3, 20, 3) },
-			{ title: 'WAN Port Speed *', name: 'wan_speed', type: 'select', options: [[0,'10Mbps Full'],[1,'10Mbps Half'],[2,'100Mbps Full'],[3,'100Mbps Half'],[4,'Autonegotiation']], value: nvram.wan_speed },
+			{ title: 'WAN Port Speed *', name: 'wan_speed', type: 'select', options: [[0,'10Mbps Full'],[1,'10Mbps Half'],[2,'100Mbps Full'],[3,'100Mbps Half'],[4,'1000Mbps Full'],[5,'Autonegotiation']], value: nvram.wan_speed },
 			null,
 /* CTF-BEGIN */
 			{ title: 'CTF (Cut-Through Forwarding)<br>and HW acceleration', name: 'f_ctf_disable', type: 'checkbox', value: nvram.ctf_disable != '1', suffix: ' <small>disables QoS and BW Limiter!<\/small>' },


### PR DESCRIPTION
Its been brought to the attention that 1000mb full is missing as an option while I get that autonegotiate should give you this speed I know what it is like to want to be able to select 1000mb as an option there is something about the implicit nature of selecting such a value. half isn't even really a thing for 1GB in production env.

And it is ruffling a few feathers not having the option.

I am unsure of where this is all handled downstream up stream or if it was something to save space.

But perhaps whe can call it 1000mb/auto in that case to make people feel a bit better if we are trying to do so it will give people the feeling of selecting 1000mb for option 4