### PR TITLE
GUI: status-overview.asp - WAN icons fix

### DIFF
--- a/release/src-rt-6.x.4708/router/www/status-overview.asp
+++ b/release/src-rt-6.x.4708/router/www/status-overview.asp
@@ -221,6 +221,22 @@ function c(id, htm) {
 	E(id).cells[1].innerHTML = htm;
 }
 
+function calcWanPortCount() {
+	var count = 0;
+
+	for (var uidx = 1; uidx <= nvram.mwan_num; ++uidx) {
+		var u = (uidx > 1) ? uidx : '';
+		if ((nvram['wan'+u+'_proto'] != 'disabled')
+/* USB-BEGIN */
+		    && (nvram['wan'+u+'_proto'] != 'lte') && (nvram['wan'+u+'_proto'] != 'ppp3g')
+/* USB-END */
+		)
+			++count;
+	}
+
+	return count;
+}
+
 function ethstates() {
 	var port = etherstates.port0;
 	if (port == 'disabled')
@@ -234,18 +250,9 @@ function ethstates() {
 		code ='<div class="section-title">Ethernet Ports State<\/div><div class="section"><table class="fields"><tr>';
 
 		/* WANs */
-		for (uidx = 1; uidx <= nvram.mwan_num; ++uidx) {
-			u = (uidx > 1) ? uidx : '';
-
-			if ((nvram['wan'+u+'_sta'] == '')
-/* USB-BEGIN */
-			    && (nvram['wan'+u+'_proto'] != 'lte') && (nvram['wan'+u+'_proto'] != 'ppp3g')
-/* USB-END */
-			) {
-				code += '<td class="title indent2"><b>WAN'+(uidx - 1)+'<\/b><\/td>';
-				++v;
-			}
-		}
+		v = calcWanPortCount();
+		for (uidx = 0; uidx < v; ++uidx)
+			code += '<td class="title indent2"><b>WAN'+uidx+'<\/b><\/td>';
 		/* LANs - both cases: 4 Ports OR 8 Ports for RT-AC88U with RTL8365MB switch (EXTSW=y) */
 		for (uidx = v; uidx <= MAX_PORT_ID; ++uidx)
 			code += '<td class="title indent2"><b>LAN'+(v > 0 ? ((uidx < 5) ? (uidx - 1) : '4-7' ) : ((uidx < 5) ? (uidx) : '5-8' ))+'<\/b><\/td>';


### PR DESCRIPTION
This fixes a little bug in the status-overview.asp Ethernet port naming when no active Ethernet ports are present.
Essentially with no Ethernet it assumes all the ports are LAN only, this modification reinforces the logic checking the VLAN configuration instead and displaying the WANs as expected.

Before:
<img width="841" height="181" alt="uDeR7J8DSV" src="https://github.com/user-attachments/assets/e31312de-64a5-4e48-af6c-b9fad9b04a7d" />


After:
<img width="849" height="177" alt="796Okg1f3H" src="https://github.com/user-attachments/assets/9927595c-9642-49a6-8c01-1adab6ef9014" />
