### PR TITLE
rc: firewall.c: fix multi-second boot stall from start_firewall holding its own lock

### DIFF
--- a/release/src-rt-6.x.4708/router/rc/firewall.c
+++ b/release/src-rt-6.x.4708/router/rc/firewall.c
@@ -2086,6 +2086,9 @@ int start_firewall(void)
 	unlink("/var/webmon/domain");
 	unlink("/var/webmon/search");
 
+	/* The following run_*_firewall_script() scripts handle their own locking */
+	simple_unlock("firewall");
+
 #ifdef TCONFIG_PPTPD
 	run_pptpd_firewall_script();
 #endif
@@ -2115,6 +2118,9 @@ int start_firewall(void)
 #ifdef TCONFIG_WIREGUARD
 	run_vpn_firewall_scripts("wg");
 #endif
+
+	/* Re-acquire the firewall lock for the remainder of start_firewall */
+	simple_lock("firewall");
 
 	fix_chain_in_drop();
 


### PR DESCRIPTION
the run_*_firewall_script() scripts handle their own locking