### PR TITLE
rc: httpd: cstats: handle LAN bridge with greater number than 9

### DIFF
--- a/release/src-rt-6.x.4708/router/cstats/cstats.c
+++ b/release/src-rt-6.x.4708/router/cstats/cstats.c
@@ -744,13 +744,7 @@ static void calc(void)
 	logmsg(LOG_DEBUG, "*** %s: cstats_exclude=[%s] cstats_include=[%s]", __FUNCTION__, exclude, include);
 
 	for (br = 0 ; br < BRIDGE_COUNT; br++) {
-		char bridge[2] = "0";
-		if (br != 0)
-			bridge[0] += br;
-		else
-			strlcpy(bridge, "", sizeof(bridge));
-
-		snprintf(name, sizeof(name), "/proc/net/ipt_account/lan%s", bridge);
+		snprintf(name, sizeof(name), (br == 0 ? "/proc/net/ipt_account/lan" : "/proc/net/ipt_account/lan%d"), br);
 
 		if (!(f = fopen(name, "r")))
 			continue;

--- a/release/src-rt-6.x.4708/router/httpd/bwm.c
+++ b/release/src-rt-6.x.4708/router/httpd/bwm.c
@@ -223,13 +223,7 @@ void asp_iptmon(int argc, char **argv)
 	for (br = 0; br < BRIDGE_COUNT; br++) {
 		wholenetstatsline = 1;
 
-		char bridge[2] = "0";
-		if (br != 0)
-			bridge[0] += br;
-		else
-			memset(bridge, 0, sizeof(bridge));
-
-		snprintf(name, sizeof(name), "/proc/net/ipt_account/lan%s", bridge);
+		snprintf(name, sizeof(name), (br == 0 ? "/proc/net/ipt_account/lan" : "/proc/net/ipt_account/lan%d"), br);
 
 		if (!(a = fopen(name, "r")))
 			continue;

--- a/release/src-rt-6.x.4708/router/httpd/iptraffic.c
+++ b/release/src-rt-6.x.4708/router/httpd/iptraffic.c
@@ -46,22 +46,16 @@ static void iptraffic_conntrack_init(void)
 	const char conntrack[] = "/proc/net/ip_conntrack";
 
 	for(br = 0; br < BRIDGE_COUNT; br++) {
-		char bridge[2] = "0";
-		if (br != 0)
-			bridge[0] += br;
-		else
-			memset(bridge, 0, sizeof(bridge));
-
 		memset(sa, 0, sizeof(sa));
-		snprintf(sa, sizeof(sa), "lan%s_ifname", bridge);
+		snprintf(sa, sizeof(sa), (br == 0 ? "lan_ifname" : "lan%d_ifname"), br);
 
 		if (strcmp(nvram_safe_get(sa), "") != 0) {
 			memset(sa, 0, sizeof(sa));
-			snprintf(sa, sizeof(sa), "lan%s_ipaddr", bridge);
+			snprintf(sa, sizeof(sa), (br == 0 ? "lan_ipaddr" : "lan%d_ipaddr"), br);
 			rip[br] = inet_addr(nvram_safe_get(sa));
 
 			memset(sa, 0, sizeof(sa));
-			snprintf(sa, sizeof(sa), "lan%s_netmask", bridge);
+			snprintf(sa, sizeof(sa), (br == 0 ? "lan_netmask" : "lan%d_netmask"), br);
 			mask[br] = inet_addr(nvram_safe_get(sa));
 			lan[br] = rip[br] & mask[br];
 		}
@@ -146,7 +140,7 @@ void asp_iptraffic(int argc, char **argv)
 	char comma, br;
 	Node tmp;
 	Node *ptr;
-	char name[] = "/proc/net/ipt_account/lanX";
+	char name[] = "/proc/net/ipt_account/lanXX";
 
 	exclude = nvram_safe_get("cstats_exclude");
 
@@ -156,13 +150,7 @@ void asp_iptraffic(int argc, char **argv)
 	comma = ' ';
 
 	for (br = 0; br < BRIDGE_COUNT; br++) {
-		char bridge[2] = "0";
-		if (br != 0)
-			bridge[0] += br;
-		else
-			memset(bridge, 0, sizeof(bridge));
-
-		snprintf(name, sizeof(name), "/proc/net/ipt_account/lan%s", bridge);
+		snprintf(name, sizeof(name), (br == 0 ? "/proc/net/ipt_account/lan" : "/proc/net/ipt_account/lan%d"), br);
 
 		if (!(a = fopen(name, "r")))
 			continue;

--- a/release/src-rt-6.x.4708/router/httpd/misc.c
+++ b/release/src-rt-6.x.4708/router/httpd/misc.c
@@ -416,24 +416,21 @@ static void print_ipv6_infos(void) /* show IPv6 DUID and addresses: wan, dns, la
 
 	/* check LAN */
 	for (br = 0; br < BRIDGE_COUNT; br++) {
-		char bridge[2] = "0";
-		if (br != 0)
-			bridge[0] += br;
-		else
-			memset(bridge, 0, sizeof(bridge));
+		char lanN[] = "lanXX";
+		snprintf(lanN, sizeof(lanN), (br == 0 ? "lan" : "lan%d"), br);
 
 		memset(buffer2, 0, sizeof(buffer2));
-		snprintf(buffer2, sizeof(buffer2), "lan%s_ipaddr", bridge);
+		snprintf(buffer2, sizeof(buffer2), "%s_ipaddr", lanN);
 		if (strcmp(nvram_safe_get(buffer2), "") != 0) {
 			/* check LANx IPv6 address and copy to buffer */
 			memset(buffer2, 0, sizeof(buffer2));
-			snprintf(buffer2, sizeof(buffer2), "lan%s_ifname", bridge);
+			snprintf(buffer2, sizeof(buffer2), "%s_ifname", lanN);
 			p_tmp = NULL;
 			p_tmp = getifaddr(nvram_safe_get(buffer2), AF_INET6, 0); /* global address */
 			if (p_tmp != NULL) {
 				memset(buffer, 0, sizeof(buffer));
 				snprintf(buffer, sizeof(buffer), "%s", p_tmp);
-				web_printf("\tip6_lan%s: '%s',\n", bridge, buffer);
+				web_printf("\tip6_%s: '%s',\n", lanN, buffer);
 			}
 			/* check LAN IPv6 link local address and copy to buffer */
 			p_tmp = NULL;
@@ -441,7 +438,7 @@ static void print_ipv6_infos(void) /* show IPv6 DUID and addresses: wan, dns, la
 			if (p_tmp != NULL) {
 				memset(buffer, 0, sizeof(buffer));
 				snprintf(buffer, sizeof(buffer), "%s", p_tmp);
-				web_printf("\tip6_lan%s_ll: '%s',\n", bridge, buffer);
+				web_printf("\tip6_%s_ll: '%s',\n", lanN, buffer);
 			}
 		}
 	}

--- a/release/src-rt-6.x.4708/router/rc/dnsmasq.c
+++ b/release/src-rt-6.x.4708/router/rc/dnsmasq.c
@@ -316,18 +316,12 @@ static void write_dhcp_ranges(FILE *f, int *do_dhcpd_hosts, int *do_dns_ptr, cha
 	do_dns = *do_dns_ptr;
 
 	for (br = 0; br < BRIDGE_COUNT; br++) {
-		char bridge[2] = "0";
-		if (br != 0)
-			bridge[0] += br;
-		else
-			memset(bridge, 0, sizeof(bridge));
-
-		snprintf(lanN_proto, sizeof(lanN_proto), "lan%s_proto", bridge);
-		snprintf(lanN_ifname, sizeof(lanN_ifname), "lan%s_ifname", bridge);
-		snprintf(lanN_ipaddr, sizeof(lanN_ipaddr), "lan%s_ipaddr", bridge);
-		snprintf(lanN_netmask, sizeof(lanN_netmask), "lan%s_netmask", bridge);
-		snprintf(dhcpdN_startip, sizeof(dhcpdN_startip), "dhcpd%s_startip", bridge);
-		snprintf(dhcpdN_endip, sizeof(dhcpdN_endip), "dhcpd%s_endip", bridge);
+		snprintf(lanN_proto, sizeof(lanN_proto), (br == 0 ? "lan_proto" : "lan%d_proto"), br);
+		snprintf(lanN_ifname, sizeof(lanN_ifname), (br == 0 ? "lan_ifname" : "lan%d_ifname"), br);
+		snprintf(lanN_ipaddr, sizeof(lanN_ipaddr), (br == 0 ? "lan_ipaddr" : "lan%d_ipaddr"), br);
+		snprintf(lanN_netmask, sizeof(lanN_netmask), (br == 0 ? "lan_netmask" : "lan%d_netmask"), br);
+		snprintf(dhcpdN_startip, sizeof(dhcpdN_startip), (br == 0 ? "dhcpd_startip" : "dhcpd%d_startip"), br);
+		snprintf(dhcpdN_endip, sizeof(dhcpdN_endip), (br == 0 ? "dhcpd_endip" : "dhcpd%d_endip"), br);
 
 		/* 0.0.0.0 marks a pure L2 bridge: do not bind DNS, DHCP or RA to it. */
 		if (!bridge_has_l3(br) || !*nvram_safe_get(lanN_ifname))
@@ -345,7 +339,7 @@ static void write_dhcp_ranges(FILE *f, int *do_dhcpd_hosts, int *do_dns_ptr, cha
 			fprintf(f, "interface=%s\n", nvram_safe_get(lanN_ifname));
 
 			/* DHCP lease time */
-			snprintf(dhcpN_lease, sizeof(dhcpN_lease), "dhcp%s_lease", bridge);
+			snprintf(dhcpN_lease, sizeof(dhcpN_lease), (br == 0 ? "dhcp_lease" : "dhcp%d_lease"), br);
 			dhcp_lease = nvram_get_int(dhcpN_lease);
 			if (dhcp_lease <= 0)
 				dhcp_lease = 1440;
@@ -939,13 +933,7 @@ static void start_dnsmasq_wet(void)
 	           4096);
 
 	for (br = 0; br < BRIDGE_COUNT; br++) {
-		char bridge[2] = "0";
-		if (br != 0)
-			bridge[0] += br;
-		else
-			memset(bridge, 0, sizeof(bridge));
-
-		snprintf(lanN_ifname, sizeof(lanN_ifname), "lan%s_ifname", bridge);
+		snprintf(lanN_ifname, sizeof(lanN_ifname), (br == 0 ? "lan_ifname" : "lan%d_ifname"), br);
 		nv = nvram_safe_get(lanN_ifname);
 
 		if (strncmp(nv, "br", 2) == 0) {

--- a/release/src-rt-6.x.4708/router/rc/firewall.c
+++ b/release/src-rt-6.x.4708/router/rc/firewall.c
@@ -575,16 +575,12 @@ static void ipt_account(void) {
 	char br;
 
 	for (br = 0 ; br < BRIDGE_COUNT; br++) {
-		char bridge[2];
-		bridge[0] = br ? '0' + br : '\0';
-		bridge[1] = '\0';
-
-		snprintf(lanN_ifname, sizeof(lanN_ifname), "lan%s_ifname", bridge);
+		snprintf(lanN_ifname, sizeof(lanN_ifname), (br == 0 ? "lan_ifname" : "lan%d_ifname"), br);
 
 		if (strcmp(nvram_safe_get(lanN_ifname), "") != 0) {
-			snprintf(lanN_ipaddr, sizeof(lanN_ipaddr), "lan%s_ipaddr", bridge);
-			snprintf(lanN_netmask, sizeof(lanN_netmask), "lan%s_netmask", bridge);
-			snprintf(lanN, sizeof(lanN), "lan%s", bridge);
+			snprintf(lanN_ipaddr, sizeof(lanN_ipaddr), (br == 0 ? "lan_ipaddr" : "lan%d_ipaddr"), br);
+			snprintf(lanN_netmask, sizeof(lanN_netmask), (br == 0 ? "lan_netmask" : "lan%d_netmask"), br);
+			snprintf(lanN, sizeof(lanN), (br == 0 ? "lan" : "lan%d"), br);
 
 			inet_aton(nvram_safe_get(lanN_ipaddr), &ipaddr);
 			inet_aton(nvram_safe_get(lanN_netmask), &netmask);
@@ -1149,24 +1145,16 @@ static void filter_input(void)
 
 	if (nvram_get_int("fw_strict_input")) {
 		for (br = 0; br < BRIDGE_COUNT; br++) {
-			char bridge[2];
-			bridge[0] = br ? '0' + br : '\0';
-			bridge[1] = '\0';
-
-			snprintf(lanN_ifname, sizeof(lanN_ifname), "lan%s_ifname", bridge);
+			snprintf(lanN_ifname, sizeof(lanN_ifname), (br == 0 ? "lan_ifname" : "lan%d_ifname"), br);
 			if (strncmp(nvram_safe_get(lanN_ifname), "br", 2) == 0) {
 				for (br2 = 0; br2 < BRIDGE_COUNT; br2++) {
 					if (br == br2)
 						continue;
 
-					char bridge2[2];
-					bridge2[0] = br2 ? '0' + br2 : '\0';
-					bridge2[1] = '\0';
-
-					snprintf(lanN_ifname2, sizeof(lanN_ifname2), "lan%s_ifname", bridge2);
+					snprintf(lanN_ifname2, sizeof(lanN_ifname2), (br2 == 0 ? "lan_ifname" : "lan%d_ifname"), br2);
 					if (strncmp(nvram_safe_get(lanN_ifname2), "br", 2) == 0) {
 
-						snprintf(lanN_ipaddr, sizeof(lanN_ipaddr), "lan%s_ipaddr", bridge2);
+						snprintf(lanN_ipaddr, sizeof(lanN_ipaddr), (br2 == 0 ? "lan_ipaddr" : "lan%d_ipaddr"), br2);
 
 						ipt_write("-A INPUT -i %s -d %s -j DROP\n", nvram_safe_get(lanN_ifname), nvram_safe_get(lanN_ipaddr));
 					}
@@ -1305,6 +1293,20 @@ static void filter_input(void)
 	/* default policy: DROP */
 }
 
+/* parse a LAN bridge id as stored in lan_access, ie. "0" ... "15"; -1 if not a valid bridge */
+static int lan_access_bridge_id(const char *s)
+{
+	char *endp;
+	long id;
+
+	if ((s == NULL) || (*s == '\0'))
+		return -1;
+
+	id = strtol(s, &endp, 10);
+
+	return ((*endp == '\0') && (id >= 0) && (id < BRIDGE_COUNT)) ? (int)id : -1;
+}
+
 static void filter_forward(void)
 {
 	char dst[128];
@@ -1348,22 +1350,21 @@ static void filter_forward(void)
 			 * 5.6.7.8 = dst addr
 			 * desc = desc
 			 */
-			int src_f, dst_f;
+			int src_f, dst_f, sbr_id, dbr_id;
 
 			if ((vstrsep(b, "<", &d, &sbr, &saddr, &dbr, &daddr, &desc) < 6) || (*d != '1'))
+				continue;
+			if (((sbr_id = lan_access_bridge_id(sbr)) < 0) || ((dbr_id = lan_access_bridge_id(dbr)) < 0))
 				continue;
 			if (!(src_f = ipt_addr(src, sizeof(src), saddr, "src", (IPT_V4 | IPT_V6), 0, "LAN access", desc)))
 				continue;
 			if (!(dst_f = ipt_addr(dst, sizeof(dst), daddr, "dst", (IPT_V4 | IPT_V6), 0, "LAN access", desc)))
 				continue;
 
-			ip46t_flagged_write(ipv6_enabled, src_f & dst_f, "-A FORWARD -i %s%s -o %s%s %s %s -j ACCEPT\n", "br", sbr, "br", dbr, src, dst);
+			ip46t_flagged_write(ipv6_enabled, src_f & dst_f, "-A FORWARD -i br%d -o br%d %s %s -j ACCEPT\n", sbr_id, dbr_id, src, dst);
 
-			if ((strcmp(src, "") == 0) && (strcmp(dst, "") == 0) &&
-			    (*sbr >= '0') && (*sbr < '0' + BRIDGE_COUNT) &&
-			    (*dbr >= '0') && (*dbr < '0' + BRIDGE_COUNT)) {
-				lanAccess[((*sbr - '0') + (*dbr - '0') * BRIDGE_COUNT)] = '1';
-			}
+			if ((strcmp(src, "") == 0) && (strcmp(dst, "") == 0))
+				lanAccess[(sbr_id + dbr_id * BRIDGE_COUNT)] = '1';
 		}
 	}
 	free(nv);
@@ -1398,11 +1399,7 @@ static void filter_forward(void)
 	}
 
 	for (br = 0; br < BRIDGE_COUNT; br++) {
-		char bridge[2];
-		bridge[0] = br ? '0' + br : '\0';
-		bridge[1] = '\0';
-
-		snprintf(lanN_ifname, sizeof(lanN_ifname), "lan%s_ifname", bridge);
+		snprintf(lanN_ifname, sizeof(lanN_ifname), (br == 0 ? "lan_ifname" : "lan%d_ifname"), br);
 		if (strncmp(nvram_safe_get(lanN_ifname), "br", 2) == 0) {
 			for (br2 = 0; br2 < BRIDGE_COUNT; br2++) {
 				if (br == br2)
@@ -1411,11 +1408,7 @@ static void filter_forward(void)
 				if (lanAccess[((br)+(br2) * BRIDGE_COUNT)] == '1')
 					continue;
 
-				char bridge2[2];
-				bridge2[0] = br2 ? '0' + br2 : '\0';
-				bridge2[1] = '\0';
-
-				snprintf(lanN_ifname2, sizeof(lanN_ifname2), "lan%s_ifname", bridge2);
+				snprintf(lanN_ifname2, sizeof(lanN_ifname2), (br2 == 0 ? "lan_ifname" : "lan%d_ifname"), br2);
 
 				if (strncmp(nvram_safe_get(lanN_ifname2), "br", 2) == 0)
 					ip46t_write(ipv6_enabled, "-A FORWARD -i %s -o %s -j DROP\n", nvram_safe_get(lanN_ifname), nvram_safe_get(lanN_ifname2));
@@ -1480,11 +1473,7 @@ static void filter_forward(void)
 #endif
 
 	for (br = 0; br < BRIDGE_COUNT; br++) {
-		char bridge[2];
-		bridge[0] = br ? '0' + br : '\0';
-		bridge[1] = '\0';
-
-		snprintf(lanN_ifname, sizeof(lanN_ifname), "lan%s_ifname", bridge);
+		snprintf(lanN_ifname, sizeof(lanN_ifname), (br == 0 ? "lan_ifname" : "lan%d_ifname"), br);
 		if (strncmp(nvram_safe_get(lanN_ifname), "br", 2) == 0)
 			ip46t_write(ipv6_enabled, "-A FORWARD -i %s -j %s\n", nvram_safe_get(lanN_ifname), chain_out_accept);
 	}

--- a/release/src-rt-6.x.4708/router/rc/network.c
+++ b/release/src-rt-6.x.4708/router/rc/network.c
@@ -891,21 +891,11 @@ void restart_wl(void)
 #endif
 
 	for (br = 0; br < BRIDGE_COUNT; br++) {
-		char bridge[2] = "0";
-		if (br != 0)
-			bridge[0] += br;
-		else
-			memset(bridge, 0, sizeof(bridge));
-
-		strlcpy(tmp, "lan", sizeof(tmp));
-		strlcat(tmp, bridge, sizeof(tmp));
-		strlcat(tmp, "_ifname", sizeof(tmp));
+		snprintf(tmp, sizeof(tmp), (br == 0 ? "lan_ifname" : "lan%d_ifname"), br);
 		lan_ifname = nvram_safe_get(tmp);
 
 		if (strncmp(lan_ifname, "br", 2) == 0) {
-			strlcpy(tmp, "lan", sizeof(tmp));
-			strlcat(tmp, bridge, sizeof(tmp));
-			strlcat(tmp, "_ifnames", sizeof(tmp));
+			snprintf(tmp, sizeof(tmp), (br == 0 ? "lan_ifnames" : "lan%d_ifnames"), br);
 
 			if ((lan_ifnames = strdup(nvram_safe_get(tmp))) != NULL) {
 				p = lan_ifnames;
@@ -1050,20 +1040,10 @@ void stop_lan_wl(void)
 #endif
 
 	for (br = 0; br < BRIDGE_COUNT; br++) {
-		char bridge[2] = "0";
-		if (br !=0 )
-			bridge[0] += br;
-		else
-			memset(bridge, 0, sizeof(bridge));
-
-		strlcpy(tmp, "lan", sizeof(tmp));
-		strlcat(tmp, bridge, sizeof(tmp));
-		strlcat(tmp, "_ifname", sizeof(tmp));
+		snprintf(tmp, sizeof(tmp), (br == 0 ? "lan_ifname" : "lan%d_ifname"), br);
 		lan_ifname = nvram_safe_get(tmp);
 
-		strlcpy(tmp, "lan", sizeof(tmp));
-		strlcat(tmp, bridge, sizeof(tmp));
-		strlcat(tmp, "_ifnames", sizeof(tmp));
+		snprintf(tmp, sizeof(tmp), (br == 0 ? "lan_ifnames" : "lan%d_ifnames"), br);
 		if ((wl_ifnames = strdup(nvram_safe_get(tmp))) != NULL) {
 			p = wl_ifnames;
 			while ((ifname = strsep(&p, " ")) != NULL) {
@@ -1119,15 +1099,7 @@ void start_lan_wl(void)
 	foreach_wif(0, NULL, set_wlmac);
 
 	for (br = 0; br < BRIDGE_COUNT; br++) {
-		char bridge[2] = "0";
-		if (br != 0)
-			bridge[0] += br;
-		else
-			memset(bridge, 0, sizeof(bridge));
-
-		strlcpy(tmp, "lan", sizeof(tmp));
-		strlcat(tmp, bridge, sizeof(tmp));
-		strlcat(tmp, "_ifname", sizeof(tmp));
+		snprintf(tmp, sizeof(tmp), (br == 0 ? "lan_ifname" : "lan%d_ifname"), br);
 		lan_ifname = nvram_safe_get(tmp);
 
 		if (strncmp(lan_ifname, "br", 2) == 0) {
@@ -1137,14 +1109,10 @@ void start_lan_wl(void)
 				eval("igs", "add", "bridge", lan_ifname);
 			}
 #endif
-			strlcpy(tmp, "lan", sizeof(tmp));
-			strlcat(tmp, bridge, sizeof(tmp));
-			strlcat(tmp, "_ipaddr", sizeof(tmp));
+			snprintf(tmp, sizeof(tmp), (br == 0 ? "lan_ipaddr" : "lan%d_ipaddr"), br);
 			inet_aton(nvram_safe_get(tmp), (struct in_addr *)&ip);
 
-			strlcpy(tmp, "lan", sizeof(tmp));
-			strlcat(tmp, bridge, sizeof(tmp));
-			strlcat(tmp, "_ifnames", sizeof(tmp));
+			snprintf(tmp, sizeof(tmp), (br == 0 ? "lan_ifnames" : "lan%d_ifnames"), br);
 
 			sta = 0;
 
@@ -1609,19 +1577,13 @@ void start_lan(void)
 	int vlan0tag = nvram_get_int("vlan0tag");
 #endif
 
+	/* NB: loops to BRIDGE_COUNT inclusive on purpose - the extra pass hits an unset
+	 * lanN_ifname, which is the only path that reaches start_ipv6() below */
 	for (br = 0; br <= BRIDGE_COUNT; br++) {
-		char bridge[2] = "0";
-		if (br != 0)
-			bridge[0] += br;
-		else
-			memset(bridge, 0, sizeof(bridge));
-
 		if ((sfd = socket(AF_INET, SOCK_RAW, IPPROTO_RAW)) < 0)
 			return;
 
-		strlcpy(tmp, "lan", sizeof(tmp));
-		strlcat(tmp, bridge, sizeof(tmp));
-		strlcat(tmp, "_ifname", sizeof(tmp));
+		snprintf(tmp, sizeof(tmp), (br == 0 ? "lan_ifname" : "lan%d_ifname"), br);
 		lan_ifname = strdup(nvram_safe_get(tmp));
 
 		if (strncmp(lan_ifname, "br", 2) == 0) {
@@ -1629,9 +1591,7 @@ void start_lan(void)
 
 			eval("brctl", "addbr", lan_ifname);
 			eval("brctl", "setfd", lan_ifname, "0");
-			strlcpy(tmp, "lan", sizeof(tmp));
-			strlcat(tmp, bridge, sizeof(tmp));
-			strlcat(tmp, "_stp", sizeof(tmp));
+			snprintf(tmp, sizeof(tmp), (br == 0 ? "lan_stp" : "lan%d_stp"), br);
 			eval("brctl", "stp", lan_ifname, nvram_safe_get(tmp));
 
 #ifdef TCONFIG_EMF
@@ -1641,17 +1601,13 @@ void start_lan(void)
 			}
 #endif
 
-			strlcpy(tmp, "lan", sizeof(tmp));
-			strlcat(tmp, bridge, sizeof(tmp));
-			strlcat(tmp, "_ipaddr", sizeof(tmp));
+			snprintf(tmp, sizeof(tmp), (br == 0 ? "lan_ipaddr" : "lan%d_ipaddr"), br);
 			inet_aton(nvram_safe_get(tmp), (struct in_addr *)&ip);
 
 			hwaddrset = 0;
 			sta = 0;
 
-			strlcpy(tmp, "lan", sizeof(tmp));
-			strlcat(tmp, bridge, sizeof(tmp));
-			strlcat(tmp, "_ifnames", sizeof(tmp));
+			snprintf(tmp, sizeof(tmp), (br == 0 ? "lan_ifnames" : "lan%d_ifnames"), br);
 			if ((lan_ifnames = strdup(nvram_safe_get(tmp))) != NULL) {
 				p = lan_ifnames;
 				while ((iftmp = strsep(&p, " ")) != NULL) {
@@ -1802,9 +1758,7 @@ void start_lan(void)
 
 		/* Get current LAN hardware address */
 		strlcpy(ifr.ifr_name, lan_ifname, IFNAMSIZ);
-		strlcpy(tmp, "lan", sizeof(tmp));
-		strlcat(tmp, bridge, sizeof(tmp));
-		strlcat(tmp, "_hwaddr", sizeof(tmp));
+		snprintf(tmp, sizeof(tmp), (br == 0 ? "lan_hwaddr" : "lan%d_hwaddr"), br);
 		if (ioctl(sfd, SIOCGIFHWADDR, &ifr) == 0) {
 			nvram_set(tmp, ether_etoa((const unsigned char *)ifr.ifr_hwaddr.sa_data, eabuf));
 		}
@@ -1815,12 +1769,8 @@ void start_lan(void)
 		set_et_qos_mode();
 
 		/* bring up and configure LAN interface */
-		strlcpy(tmp, "lan", sizeof(tmp));
-		strlcat(tmp, bridge, sizeof(tmp));
-		strlcat(tmp, "_ipaddr", sizeof(tmp));
-		strlcpy(tmp2, "lan", sizeof(tmp2));
-		strlcat(tmp2, bridge, sizeof(tmp2));
-		strlcat(tmp2, "_netmask", sizeof(tmp2));
+		snprintf(tmp, sizeof(tmp), (br == 0 ? "lan_ipaddr" : "lan%d_ipaddr"), br);
+		snprintf(tmp2, sizeof(tmp2), (br == 0 ? "lan_netmask" : "lan%d_netmask"), br);
 		ifconfig(lan_ifname, IFUP | IFF_ALLMULTI, nvram_safe_get(tmp), nvram_safe_get(tmp2));
 
 #ifdef TCONFIG_IPV6
@@ -1888,22 +1838,12 @@ void stop_lan(void)
 #endif
 
 	for (br = 0; br < BRIDGE_COUNT; br++) {
-		char bridge[2] = "0";
-		if (br != 0)
-			bridge[0] += br;
-		else
-			memset(bridge, 0, sizeof(bridge));
-
-		strlcpy(tmp, "lan", sizeof(tmp));
-		strlcat(tmp, bridge, sizeof(tmp));
-		strlcat(tmp, "_ifname", sizeof(tmp));
+		snprintf(tmp, sizeof(tmp), (br == 0 ? "lan_ifname" : "lan%d_ifname"), br);
 		lan_ifname = nvram_safe_get(tmp);
 		ifconfig(lan_ifname, 0, NULL, NULL);
 
 		if (strncmp(lan_ifname, "br", 2) == 0) {
-			strlcpy(tmp, "lan", sizeof(tmp));
-			strlcat(tmp, bridge, sizeof(tmp));
-			strlcat(tmp, "_ifnames", sizeof(tmp));
+			snprintf(tmp, sizeof(tmp), (br == 0 ? "lan_ifnames" : "lan%d_ifnames"), br);
 			if ((lan_ifnames = strdup(nvram_safe_get(tmp))) != NULL) {
 				p = lan_ifnames;
 				while ((iftmp = strsep(&p, " ")) != NULL) {

--- a/release/src-rt-6.x.4708/router/rc/openvpn.c
+++ b/release/src-rt-6.x.4708/router/rc/openvpn.c
@@ -66,23 +66,19 @@ static void write_ovpn_cstats_rules(FILE *fp, const char *iface, const char *dir
 	char lanN_netmask[] = "lanXX_netmask";
 	char lanN[] = "lanXX";
 	char netaddrnetmask[] = "255.255.255.255/255.255.255.255";
-	char bridge[2];
 	char br;
 
 	if (!nvram_match("cstats_enable", "1"))
 		return;
 
 	for (br = 0; br < BRIDGE_COUNT; br++) {
-		bridge[0] = br ? '0' + br : '\0';
-		bridge[1] = '\0';
-
-		snprintf(lanN_ifname, sizeof(lanN_ifname), "lan%s_ifname", bridge);
+		snprintf(lanN_ifname, sizeof(lanN_ifname), (br == 0 ? "lan_ifname" : "lan%d_ifname"), br);
 		if (strcmp(nvram_safe_get(lanN_ifname), "") == 0)
 			continue;
 
-		snprintf(lanN_ipaddr, sizeof(lanN_ipaddr), "lan%s_ipaddr", bridge);
-		snprintf(lanN_netmask, sizeof(lanN_netmask), "lan%s_netmask", bridge);
-		snprintf(lanN, sizeof(lanN), "lan%s", bridge);
+		snprintf(lanN_ipaddr, sizeof(lanN_ipaddr), (br == 0 ? "lan_ipaddr" : "lan%d_ipaddr"), br);
+		snprintf(lanN_netmask, sizeof(lanN_netmask), (br == 0 ? "lan_netmask" : "lan%d_netmask"), br);
+		snprintf(lanN, sizeof(lanN), (br == 0 ? "lan" : "lan%d"), br);
 
 		if (!inet_aton(nvram_safe_get(lanN_ipaddr), &ipaddr))
 			continue;

--- a/release/src-rt-6.x.4708/router/rc/services.c
+++ b/release/src-rt-6.x.4708/router/rc/services.c
@@ -1370,14 +1370,10 @@ void start_upnp(void)
 	fprintf(f, "%s\n", nvram_safe_get("upnp_custom"));
 
 	for (br = 0; br < BRIDGE_COUNT; br++) {
-		char bridge[2];
-		bridge[0] = br ? '0' + br : '\0';
-		bridge[1] = '\0';
-
-		snprintf(lanN_ipaddr, sizeof(lanN_ipaddr), "lan%s_ipaddr", bridge);
-		snprintf(lanN_netmask, sizeof(lanN_netmask), "lan%s_netmask", bridge);
-		snprintf(lanN_ifname, sizeof(lanN_ifname), "lan%s_ifname", bridge);
-		snprintf(upnp_lanN, sizeof(upnp_lanN), "upnp_lan%s", bridge);
+		snprintf(lanN_ipaddr, sizeof(lanN_ipaddr), (br == 0 ? "lan_ipaddr" : "lan%d_ipaddr"), br);
+		snprintf(lanN_netmask, sizeof(lanN_netmask), (br == 0 ? "lan_netmask" : "lan%d_netmask"), br);
+		snprintf(lanN_ifname, sizeof(lanN_ifname), (br == 0 ? "lan_ifname" : "lan%d_ifname"), br);
+		snprintf(upnp_lanN, sizeof(upnp_lanN), (br == 0 ? "upnp_lan" : "upnp_lan%d"), br);
 
 		lanip = nvram_safe_get(lanN_ipaddr);
 		lanmask = nvram_safe_get(lanN_netmask);
@@ -1808,12 +1804,8 @@ void start_igmp_proxy(void)
 			}
 
 			for (br = 0; br < BRIDGE_COUNT; br++) {
-				char bridge[2];
-				bridge[0] = br ? '0' + br : '\0';
-				bridge[1] = '\0';
-
-				snprintf(lanN_ifname, sizeof(lanN_ifname), "lan%s_ifname", bridge);
-				snprintf(multicast_lanN, sizeof(multicast_lanN), "multicast_lan%s", bridge);
+				snprintf(lanN_ifname, sizeof(lanN_ifname), (br == 0 ? "lan_ifname" : "lan%d_ifname"), br);
+				snprintf(multicast_lanN, sizeof(multicast_lanN), (br == 0 ? "multicast_lan" : "multicast_lan%d"), br);
 
 				if ((strcmp(nvram_safe_get(multicast_lanN), "1") == 0) && (strcmp(nvram_safe_get(lanN_ifname), "") != 0)) {
 				/*


### PR DESCRIPTION
Several places still use "char bridge[2]" which can only calculate up to 9 bridges, but we are now configuratble for up to 16. This commits changes most of those instance to use the ternary method which has been the most dominant method up to this point.