### PR TITLE
rc: qos.c: create the QOSSIZE chain whenever a size rule needs it

### DIFF
--- a/release/src-rt-6.x.4708/router/rc/qos.c
+++ b/release/src-rt-6.x.4708/router/rc/qos.c
@@ -113,6 +113,7 @@ void ipt_qos(void)
 	unsigned long prev_max;
 	const char *qface;
 	int sizegroup;
+	int sizechain;
 	int class_flag;
 	int rule_num;
 	unsigned int mwan_num;
@@ -132,6 +133,7 @@ void ipt_qos(void)
 	inuse = 0;
 	class_flag = 0;
 	sizegroup = 0;
+	sizechain = 0;
 	prev_max = 0;
 	rule_num = 0;
 
@@ -253,7 +255,8 @@ void ipt_qos(void)
 				else {
 					max = strtoul(p, NULL, 10);
 					snprintf(saddr + strlen(saddr), sizeof(saddr) - strlen(saddr), "%lu:%lu", min * 1024, (max * 1024) - 1);
-					if (!sizegroup) {
+					if (!sizechain) {
+						sizechain = 1;
 						/* create table of connbytes sizes, pass appropriate connections there and only continue processing them if mark was wiped */
 						ip46t_write(ipv6_enabled,
 						            ":QOSSIZE - [0:0]\n"


### PR DESCRIPTION
The QOSSIZE chain was created under "if (!sizegroup)", but sizegroup is also incremented for a layer7 rule, where it only means "every rule from here on must stay reclassifiable" and no chain is involved.

A layer7 rule followed by a rule with a bounded transfer range therefore emitted "-A QOSSIZE" rules for a chain that was never declared, and since iptables-restore is all or nothing, the whole mangle table failed to load and QoS did not come up at all.

Track whether the chain has been created in its own flag.